### PR TITLE
Unplaced tiles support and NullPlacer code

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -112,9 +112,12 @@ def TileElement : OpInterface<"TileElement", [
       ConcreteOp op = llvm::cast<ConcreteOp>(this->getOperation());
       std::string nameWithoutDialect =
           op.getOperationName().str().substr(op.getOperationName().find('.') + 1);
-      setNameFn(op.getResult(), nameWithoutDialect + "_" +
-                                    std::to_string(getTileID().col) + "_" +
-                                    std::to_string(getTileID().row));
+      std::string col_str =
+        getTileID().col >= 0 ? std::to_string(getTileID().col) : "c";
+      std::string row_str =
+        getTileID().row >= 0 ? std::to_string(getTileID().row) : "r";
+      setNameFn(op.getResult(),
+                nameWithoutDialect + "_" + col_str + "_" + row_str);
     }
   }];
 }

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -66,14 +66,13 @@ def AIE_DeviceOp: AIE_Op<"device", [
 }
 
 def AIE_TileOp: AIE_Op<"tile", [
-    Pure,
     FlowEndPoint,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]>, Results<(outs Index:$result)> {
   let arguments = (
-    ins ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$col,
-        ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$row,
+    ins ConfinedAttr<AIEI32Attr, [IntMinValue<-1>]>:$col,
+        ConfinedAttr<AIEI32Attr, [IntMinValue<-1>]>:$row,
         OptionalAttr<StrAttr>:$allocation_scheme
   );
 
@@ -123,9 +122,7 @@ def AIE_TileOp: AIE_Op<"tile", [
     static AIE::TileOp getOrCreate(mlir::OpBuilder builder, AIE::DeviceOp device, int col, int row);
   }];
 
-  let assemblyFormat = [{
-    `(` $col `,` $row `)` attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let hasVerifier = 1;
 
@@ -143,9 +140,9 @@ def AIE_TileOp: AIE_Op<"tile", [
          tileName = "shim_pl_" + tileName;
        else if (isShimTile())
          tileName = "shim_" + tileName;
-       setNameFn(getResult(), tileName + "_" +
-                                  std::to_string(getCol()) + "_" +
-                                  std::to_string(getRow()));
+       std::string col_str = getCol() >= 0 ? std::to_string(getCol()) : "c"; 
+       std::string row_str = getRow() >= 0 ? std::to_string(getRow()) : "r"; 
+       setNameFn(getResult(), tileName + "_" + col_str + "_" + row_str);
     }
   }];
 
@@ -1240,9 +1237,12 @@ def AIE_LockOp: AIE_Op<"lock", [
       else {
         std::string nameWithoutDialect =
             getOperationName().str().substr(getOperationName().find('.') + 1);
+        std::string col_str =
+          getTileID().col >= 0 ? std::to_string(getTileID().col) : "c";
+        std::string row_str =
+          getTileID().row >= 0 ? std::to_string(getTileID().row) : "r";
         setNameFn(getResult(), nameWithoutDialect + "_" +
-              std::to_string(getTileID().col) + "_" +
-              std::to_string(getTileID().row));
+              std::to_string(getTileID().col) + "_" + col_str + "_" + row_str);
       }
     }
   }];

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -696,7 +696,7 @@ public:
     return 6; /* 1 Shim row, 1 memtile row, and 4 Core rows. */
   }
 
-  bool isCoreTile(int col, int row) const override { return row > 1; }
+  bool isCoreTile(int col, int row) const override { return row > 1 || row == -1; }
   bool isMemTile(int col, int row) const override { return row == 1; }
 
   bool isShimPLTile(int col, int row) const override {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1185,6 +1185,76 @@ TileOp TileOp::getOrCreate(mlir::OpBuilder builder, DeviceOp device, int col,
 }
 
 //===----------------------------------------------------------------------===//
+// Custom Printer and Parser for TileOp
+//===----------------------------------------------------------------------===//
+
+ParseResult TileOp::parse(OpAsmParser &parser, OperationState &result) {
+  IntegerAttr colAttr;
+  IntegerAttr rowAttr;
+  if (parser.parseLParen())
+    return failure();
+
+  if (!parser.parseOptionalQuestion()) {
+    // set colAttr to -1
+    colAttr = parser.getBuilder().getIntegerAttr(
+        parser.getBuilder().getIntegerType(32), -1);
+  } else if (parser.parseCustomAttributeWithFallback(
+                 colAttr, parser.getBuilder().getIntegerType(32))) {
+    return failure();
+  }
+  if (colAttr)
+    result.getOrAddProperties<TileOp::Properties>().col = colAttr;
+  if (parser.parseComma())
+    return failure();
+
+  if (!parser.parseOptionalQuestion()) {
+    // set colAttr to -1
+    rowAttr = parser.getBuilder().getIntegerAttr(
+        parser.getBuilder().getIntegerType(32), -1);
+  } else if (parser.parseCustomAttributeWithFallback(
+                 rowAttr, parser.getBuilder().getIntegerType(32))) {
+    return failure();
+  }
+  if (rowAttr)
+    result.getOrAddProperties<TileOp::Properties>().row = rowAttr;
+  if (parser.parseRParen())
+    return failure();
+  {
+    auto loc = parser.getCurrentLocation();
+    (void)loc;
+    if (parser.parseOptionalAttrDict(result.attributes))
+      return failure();
+    if (failed(verifyInherentAttrs(result.name, result.attributes, [&]() {
+          return parser.emitError(loc)
+                 << "'" << result.name.getStringRef() << "' op ";
+        })))
+      return failure();
+  }
+  Type odsBuildableType0 = parser.getBuilder().getIndexType();
+  result.addTypes(odsBuildableType0);
+  return success();
+}
+
+void TileOp::print(OpAsmPrinter &printer) {
+  printer << "(";
+  if (getColAttr().getInt() < 0)
+    printer << "?";
+  else
+    printer.printAttributeWithoutType(getColAttr());
+  printer << ",";
+  printer << ' ';
+  if (getRowAttr().getInt() < 0)
+    printer << "?";
+  else
+    printer.printAttributeWithoutType(getRowAttr());
+  printer << ")";
+  SmallVector<StringRef, 2> elidedAttrs;
+  elidedAttrs.push_back("col");
+  elidedAttrs.push_back("row");
+  printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+}
+
+//===----------------------------------------------------------------------===//
 // ShimSwitchboxOp
 //===----------------------------------------------------------------------===//
 

--- a/python/iron/device/device.py
+++ b/python/iron/device/device.py
@@ -155,12 +155,21 @@ class Device(Resolvable):
 
     def resolve_tile(
         self,
-        tile: Tile,
+        t: Tile,
         loc: ir.Location | None = None,
         ip: ir.InsertionPoint | None = None,
     ) -> None:
-        self._tiles[tile.col][tile.row].resolve(loc, ip, tile.allocation_scheme)
-        tile.op = self._tiles[tile.col][tile.row].op
+        if (t.col < 0) or (t.row < 0):
+            t.op = tile(
+                t.col,
+                t.row,
+                loc=loc,
+                ip=ip,
+                allocation_scheme=t.allocation_scheme,
+            )
+        else:
+            self._tiles[t.col][t.row].resolve(loc, ip, t.allocation_scheme)
+            t.op = self._tiles[t.col][t.row].op
 
 
 class NPUBase(Device):

--- a/python/iron/device/tile.py
+++ b/python/iron/device/tile.py
@@ -12,11 +12,12 @@ from ...dialects.aie import TileOp
 class Tile:
     """An object representing a single component denoted by coordinates on a device."""
 
-    def __init__(self, col: int, row: int, allocation_scheme: str = None) -> None:
+    def __init__(self, col: int, row: int, allocation_scheme: str = None, logical: bool = False) -> None:
         self.col: int = col
         self.row: int = row
         self.allocation_scheme: str | None = allocation_scheme
         self._op: TileOp | None = None
+        self.logical: bool = logical
         # TODO: each tile should probably have a type, e.g., Shim or Mem or Compute
 
     @property
@@ -34,6 +35,8 @@ class Tile:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Tile):
             return NotImplemented
+        if self.logical or other.logical:
+            return id(self) == id(other)
         return self.col == other.col and self.row == other.row
 
     def __str__(self) -> str:

--- a/python/iron/placers.py
+++ b/python/iron/placers.py
@@ -10,7 +10,7 @@ from abc import ABCMeta, abstractmethod
 import statistics
 
 from .device import Device
-from .runtime import Runtime
+from .runtime import Runtime, RuntimeEndpoint
 from .worker import Worker
 from .device import AnyComputeTile, AnyMemTile, AnyShimTile, Tile
 from .dataflow import ObjectFifoHandle, ObjectFifoLink, ObjectFifoEndpoint
@@ -39,6 +39,249 @@ class Placer(metaclass=ABCMeta):
         """
         ...
 
+class NullPlacer(Placer):
+    """
+    NullPlacer is a minimal placer that does not attempt
+    to optimize placement. It only allocates physical tiles
+    and keeps track of DMA channel usage.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def make_placement(
+        self,
+        device: Device,
+        rt: Runtime,
+        workers: list[Worker],
+        object_fifos: set[ObjectFifoHandle],
+    ):
+        comp_tiles: list[Tile] = []
+        shim_tiles: list[Tile] = []
+        mem_tiles: list[Tile] = []
+
+        channels_in: dict[Tile, int] = {}
+        channels_out: dict[Tile, int] = {}
+
+        # Place workers and update their channel usage
+        for worker in workers:
+            if worker.tile == AnyComputeTile:
+                w_tile = Tile(-1, -1, logical=True)
+                worker.place(w_tile)
+                comp_tiles.append(w_tile)
+
+            for buffer in worker.buffers:
+                buffer.place(worker.tile)
+
+        # Place ObjectFifo endpoints
+        fifos_to_process = list(object_fifos)
+        while fifos_to_process:
+            ofh = fifos_to_process.pop()
+            all_eps = ofh.all_of_endpoints()
+            ofh_eps = ofh._object_fifo._get_endpoint(is_prod=ofh._is_prod)
+            link_eps = [ofe for ofe in all_eps if isinstance(ofe, ObjectFifoLink)]
+            
+            # Place normal endpoints for this handle
+            for ofe in ofh_eps:
+                if isinstance(ofe, Worker):
+                    continue
+
+                if ofe.tile in (AnyMemTile, AnyShimTile):
+                    if isinstance(ofe, ObjectFifoLink):
+                        continue
+
+                    num_chans, link_chans = self._get_channel_reqs(ofe, ofh._is_prod)
+                    tiles_list, chans, other_chans = self._get_tile_alloc_lists(
+                        ofe,
+                        comp_tiles,
+                        mem_tiles,
+                        shim_tiles,
+                        channels_in,
+                        channels_out,
+                        ofh._is_prod,
+                    )
+
+                    self._place_endpoint(
+                        ofe,
+                        chans,
+                        other_chans,
+                        num_chans,
+                        link_chans,
+                        tiles_list,
+                        device,
+                        ofh._is_prod,
+                    )
+
+            # Place link endpoints for this handle
+            for ofl in link_eps:
+                if ofl.tile in (AnyMemTile, AnyComputeTile):
+                    num_chans, link_chans = self._get_channel_reqs(ofl, ofh._is_prod)
+                    tiles_list, chans, other_chans = self._get_tile_alloc_lists(
+                        ofl,
+                        comp_tiles,
+                        mem_tiles,
+                        shim_tiles,
+                        channels_in,
+                        channels_out,
+                        ofh._is_prod,
+                    )
+
+                    self._place_endpoint(
+                        ofl,
+                        chans,
+                        other_chans,
+                        num_chans,
+                        link_chans,
+                        tiles_list,
+                        device,
+                        ofh._is_prod,
+                    )
+
+            self.sort_by_overlap(fifos_to_process, ofh)
+
+    def _get_channel_reqs(self, ofe, is_prod):
+        """
+        Returns (primary_channels, secondary_channels).
+        Secondary channels are used bc links use channels
+        in both directions.
+        """
+        if isinstance(ofe, ObjectFifoLink):
+            if is_prod:
+                return len(ofe._srcs), len(ofe._dsts)
+            else:
+                return len(ofe._dsts), len(ofe._srcs)
+        return 1, 0
+
+    def _get_tile_alloc_lists(
+        self,
+        ofe: ObjectFifoEndpoint,
+        comp_tiles: list[Tile],
+        mem_tiles: list[Tile],
+        shim_tiles: list[Tile],
+        channels_in: dict[Tile, int],
+        channels_out: dict[Tile, int],
+        is_prod: bool,
+    ):
+        if ofe.tile == AnyMemTile:
+            return (
+                mem_tiles,
+                (channels_out if is_prod else channels_in),
+                (channels_in if is_prod else channels_out),
+            )
+        elif ofe.tile == AnyShimTile:
+            return (
+                shim_tiles,
+                (channels_in if is_prod else channels_out),
+                (channels_out if is_prod else channels_in),
+            )
+        elif ofe.tile == AnyComputeTile:
+            return (
+                comp_tiles,
+                (channels_out if is_prod else channels_in),
+                (channels_in if is_prod else channels_out),
+            )
+        else:
+            raise ValueError(f"Unknown tile type: {ofe.tile} for endpoint {ofe}")
+
+    def _update_channels(
+        self,
+        chans: dict[Tile, int],
+        tile: Tile,
+        num_req_chans: int,
+        device: Device,
+        is_prod: bool,
+        is_link: bool = False,
+        num_link_chans: int = 0,
+        link_chans: dict[Tile, int] = {},
+    ):
+        cur = chans.get(tile, 0)
+        if cur + num_req_chans > device.get_num_connections(tile, is_prod):
+            return False
+
+        if is_link:
+            other_cur = link_chans.get(tile, 0)
+            if other_cur + num_link_chans > device.get_num_connections(tile, not is_prod):
+                return False
+            link_chans[tile] = other_cur + num_link_chans
+
+        chans[tile] = cur + num_req_chans
+        return True
+
+    def _place_endpoint(
+        self,
+        ofe: ObjectFifoEndpoint,
+        chans: dict[Tile, int],
+        other_chans: dict[Tile, int],
+        num_req_chans: int,
+        num_link_chans: int,
+        tiles_list: list[Tile],
+        device: Device,
+        is_prod: bool,
+    ):
+        is_link = isinstance(ofe, ObjectFifoLink)
+        for p_tile in tiles_list:
+            if self._update_channels(
+                chans,
+                p_tile,
+                num_req_chans,
+                device,
+                is_prod,
+                is_link,
+                num_link_chans,
+                other_chans,
+            ):
+                ofe.place(p_tile)
+                return
+
+        # Create a new tile if no existing one works
+        if ofe.tile == AnyComputeTile:
+            p_tile = Tile(-1, -1, logical=True)
+        elif ofe.tile == AnyMemTile:
+            p_tile = Tile(-1, 1, logical=True)
+        else:  # AnyShimTile
+            p_tile = Tile(-1, 0, logical=True)
+
+        if self._update_channels(
+            chans,
+            p_tile,
+            num_req_chans,
+            device,
+            is_prod,
+            is_link,
+            num_link_chans,
+            other_chans,
+        ):
+            ofe.place(p_tile)
+            tiles_list.append(p_tile)
+        else:
+            raise ValueError(
+                f"Requested {'OUT' if is_prod else 'IN'} DMA channels "
+                f"exceed capacity for tile {p_tile} {id(p_tile)}"
+            )
+
+    def sort_by_overlap(
+        self,
+        fifo_handles: list[ObjectFifoHandle],
+        ref_handle: ObjectFifoHandle,
+    ):  
+        '''
+        Utility function that sorts net processing so nets with
+        shared endpoints are more likely to share mem/shim tiles.
+        '''
+        # Filter RuntimeEndpoint due to __eq__ overwrite
+        ref_eps = {
+            ep for ep in ref_handle.all_of_endpoints()
+            if not isinstance(ep, RuntimeEndpoint)
+        }
+        fifo_handles.sort(
+            key=lambda h: len(
+                ref_eps & {
+                    ep for ep in h.all_of_endpoints()
+                    if not isinstance(ep, RuntimeEndpoint)
+                }
+            ),
+            reverse=True,
+        )       
 
 class SequentialPlacer(Placer):
     """SequentialPlacer is a simple implementation of a placer. The SequentialPlacer is so named

--- a/python/iron/program.py
+++ b/python/iron/program.py
@@ -12,7 +12,7 @@ from ..dialects.aie import device, tile
 
 from .device import Device
 from .runtime import Runtime
-from .placers import Placer
+from .placers import Placer, NullPlacer
 from .resolvable import Resolvable
 
 # import aie.utils.trace as trace_utils
@@ -64,12 +64,19 @@ class Program:
                     )
 
                 # Collect all tiles
-                all_tiles = []
-                for w in self._rt.workers:
-                    all_tiles.append(w.tile)
-                for f in all_fifos:
-                    all_tiles.extend([e.tile for e in f.all_of_endpoints()])
-
+                if isinstance(placer, NullPlacer):
+                    all_tiles = set()
+                    for w in self._rt.workers:
+                        all_tiles.add(w.tile)   
+                    for f in all_fifos:
+                        all_tiles.update(e.tile for e in f.all_of_endpoints())
+                else:
+                    all_tiles = []
+                    for w in self._rt.workers:
+                        all_tiles.append(w.tile)
+                    for f in all_fifos:
+                        all_tiles.extend([e.tile for e in f.all_of_endpoints()])
+                    
                 # Resolve tiles
                 for t in all_tiles:
                     self._device.resolve_tile(t)
@@ -112,7 +119,6 @@ class Program:
 
                 # In/Out Sequence
                 self._rt.resolve()
-
             self._print_verify(ctx)
             return ctx.module
 

--- a/python/iron/runtime/__init__.py
+++ b/python/iron/runtime/__init__.py
@@ -1,1 +1,1 @@
-from .runtime import Runtime
+from .runtime import Runtime, RuntimeEndpoint


### PR DESCRIPTION
To defer tile placement, this pr:

- Updates tile dialect and use custom printer to show unplaced as `aie.tile(?, ?)` for compute tiles, `aie.tile(?, 1)` for mems, and `aie.tile(?, 0)` for shims. Underlying value is represented as **-1** .
- Relax tile constraint in `targetModel` to not fail mlir verification
- IRON **NullPlacer** does not do tile placement, but infers number of shim and mem tile allocation.
- Overwrite tile comparator in IRON because we cannot use `coordinate` overload.