### PR TITLE
Add intra-tile ObjectFifo lowering, use ArrayAttr for hopTileAttr, make ObjectFifo ordering in IRON MLIR deterministic 

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEAttrs.td
+++ b/include/aie/Dialect/AIE/IR/AIEAttrs.td
@@ -207,10 +207,4 @@ def PacketInfoAttr : AttrDef<AIE_Dialect, "PacketInfo", []> {
 def InitValuesArrayAttr
   : OptionalAttr<TypedArrayAttrBase<ElementsAttr, "array of ElementsAttr">>;
 
-def IntArray1DAttr : ArrayOfAttr<AIE_Dialect, "IntArray1D", "int_array_1d", "mlir::IntegerAttr">;
-
-def IntArray2DAttr : ArrayOfAttr<AIE_Dialect, "IntArray2D", "int_array_2d", "xilinx::AIE::IntArray1DAttr">;
-
-def IntArray3DAttr : ArrayOfAttr<AIE_Dialect, "IntArray3D", "int_array_3d", "xilinx::AIE::IntArray2DAttr">;
-
 #endif // AIE_ATTRS

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -464,7 +464,7 @@ def AIE_CircuitPathOp : AIE_Op<"circuit_path", []> {
         Variadic<Index>:$dests,
         WireBundle:$dest_bundle,
         ConfinedAttr<DenseI32ArrayAttr, [DenseArrayNonNegative<DenseI32ArrayAttr>]>:$dest_channels,
-        IntArray3DAttr:$hop_tile_ids
+        ArrayAttr:$hop_tile_ids
   );
 
   let summary = "A circuit-switched connection between cores";
@@ -487,6 +487,27 @@ def AIE_CircuitPathOp : AIE_Op<"circuit_path", []> {
     `(` $source `:` $source_bundle `,` `[` $dests `]` `:` $dest_bundle `)` attr-dict
   }];
 
+  let extraClassDeclaration = [{
+    std::vector<std::vector<TileID>> getTilesAlongPath() {
+      std::vector<std::vector<TileID>> paths;
+
+      auto arr3dAttr = getHopTileIds();
+
+      for (auto arr2dAttrRaw : arr3dAttr) {
+        auto arr2dAttr = llvm::dyn_cast<mlir::ArrayAttr>(arr2dAttrRaw);
+        std::vector<TileID> pathPerDst;
+
+        for (auto arr1dAttrRaw : arr2dAttr) {
+          auto arr1dAttr = llvm::dyn_cast<mlir::ArrayAttr>(arr1dAttrRaw);
+          int col = llvm::dyn_cast<mlir::IntegerAttr>(arr1dAttr[0]).getInt();
+          int row = llvm::dyn_cast<mlir::IntegerAttr>(arr1dAttr[1]).getInt();
+          pathPerDst.push_back({col, row});
+        }
+        paths.push_back(std::move(pathPerDst));
+      }
+      return paths;
+    }
+  }];
 }
 
 def AIE_FlowOp: AIE_Op<"flow", []> {
@@ -1766,7 +1787,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
         OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<1>]>>:$repeat_count,
         InitValuesArrayAttr:$initValues,
         OptionalAttr<BDPadLayoutArrayAttr>:$padDimensions,
-        OptionalAttr<IntArray3DAttr>:$hop_tile_ids
+        OptionalAttr<ArrayAttr>:$hop_tile_ids
   );
 
   let assemblyFormat = [{

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoToPath.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoToPath.cpp
@@ -1526,7 +1526,7 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
                                     consumerWireType, dstChannelsAttr,
                                     producer.getHopTileIds().has_value() ?
                                         producer.getHopTileIdsAttr()
-                                        : IntArray3DAttr());
+                                        : ArrayAttr::get(builder.getContext(), {}));
     }
 
     //===------------------------------------------------------------------===//

--- a/lib/Dialect/AIE/Transforms/AIEPathToRouting.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathToRouting.cpp
@@ -146,27 +146,6 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
     return channel;
   }
 
-  std::vector<std::vector<TileID>> getTilesAlongPath(ArrayRef<IntArray2DAttr> arr3dAttr) {
-    std::vector<std::vector<TileID>> hops;
-
-    if (arr3dAttr.empty())
-      return hops; // return empty if no hops
-
-    for (auto arr2dAttr : arr3dAttr) {
-      std::vector<TileID> hopsPerDst;
-
-      for (auto arr1dAttr : arr2dAttr) {
-        assert(arr1dAttr.size() == 2);
-        int col = arr1dAttr[0].getInt();
-        int row = arr1dAttr[1].getInt();
-        hopsPerDst.push_back({col, row});
-      }
-      hops.push_back(std::move(hopsPerDst));
-    }
-
-    return hops;
-  }
-
   TileOp getTile(OpBuilder &builder, int col, int row) {
     if (coordToTile.count({col, row})) {
       return coordToTile[{col, row}];
@@ -243,9 +222,8 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
 
       WireBundle srcBundle = pathOp.getSourceBundle();
       int srcChannel = pathOp.getSourceChannel();
-      llvm::ArrayRef<IntArray2DAttr> hops = pathOp.getHopTileIds();
-      std::vector<std::vector<TileID>> pathTiles =
-          getTilesAlongPath(hops);
+      std::vector<std::vector<TileID>> pathTiles = pathOp.getTilesAlongPath();
+
       LLVM_DEBUG({
         auto srcTile = cast<TileOp>(pathOp.getSource().getDefiningOp());
         TileID srcTileId = {srcTile.colIndex(), srcTile.rowIndex()};

--- a/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
@@ -45,25 +45,23 @@ struct AIEPlaceTilesPass : public AIEPlaceTilesBase<AIEPlaceTilesPass> {
       auto route_info = input["nets"][i]["routing_info"];
 
       if (route_info["connection_type"] == "circuit_switch") {
-        SmallVector<IntArray2DAttr> outerArray;
+        SmallVector<Attribute> outerArray;
 
         for (const auto &hopPath : route_info["intermediates"]) {
-          SmallVector<IntArray1DAttr> innerArray; 
+          SmallVector<Attribute> innerArray;
 
           for (const auto &coords : hopPath) {
-            SmallVector<IntegerAttr> coordAttrs;
+            SmallVector<Attribute> coordAttrs;
             coordAttrs.push_back(builder.getI32IntegerAttr(coords[0].get<int>()));
             coordAttrs.push_back(builder.getI32IntegerAttr(coords[1].get<int>()));
 
-            auto coordAttr = IntArray1DAttr::get(fifoOp.getContext(), coordAttrs);
+            auto coordAttr = builder.getArrayAttr(coordAttrs); // 1D array
             innerArray.push_back(coordAttr);
           }
-
-          auto hopPathAttr = IntArray2DAttr::get(fifoOp.getContext(), innerArray); 
+          auto hopPathAttr = builder.getArrayAttr(innerArray); // 2D array
           outerArray.push_back(hopPathAttr);
         }
-
-        auto fullAttr = IntArray3DAttr::get(fifoOp.getContext(), outerArray); 
+        auto fullAttr = builder.getArrayAttr(outerArray); // 3D array as plain ArrayAttr
         fifoOp.setHopTileIdsAttr(fullAttr);
         fifoOp.setVia_DMAAttr(builder.getBoolAttr(true));
       }
@@ -76,6 +74,17 @@ struct AIEPlaceTilesPass : public AIEPlaceTilesBase<AIEPlaceTilesPass> {
         }
         fifoOp.setViaSharedMemAttr(ArrayAttr::get(fifoOp.getContext(), 
             shareDirectionAttrs));
+      }
+      else if (route_info["connection_type"] == "intra_tile") {
+        SmallVector<Attribute> shareDirectionAttrs;
+        shareDirectionAttrs.push_back(builder.getIntegerAttr(
+            builder.getI32Type(), -1));
+        fifoOp.setViaSharedMemAttr(ArrayAttr::get(fifoOp.getContext(), 
+            shareDirectionAttrs));
+      }
+      else {
+        fifoOp.emitError("Unsupported connection type in JSON");
+        return;
       }
     }
     LLVM_DEBUG(llvm::dbgs() << "FIFOs configured successfully.\n");

--- a/python/iron/program.py
+++ b/python/iron/program.py
@@ -56,7 +56,7 @@ class Program:
                 all_fifos.update(self._rt.fifos)
                 for w in self._rt.workers:
                     all_fifos.update(w.fifos)
-
+                all_fifos = sorted(all_fifos, key=lambda obj: obj.name)
                 if placer:
                     # TODO: should maybe just take runtime?
                     placer.make_placement(


### PR DESCRIPTION
### Summary
PnR now recognizes intra-tile ObjectFifos, which are used to synchronize across kernels within the same core. Added lowering to support routing for this.

### Changes
- Updated `hop_tile_ids` attribute to use `ArrayAttr` instead of the custom `3dArrayAttr`; this is for easier Python bindings in the upcoming NullPlacer overhaul.
- Integrated [#2565](https://github.com/Xilinx/mlir-aie/pull/2565) from MLIR-AIE main, ensuring deterministic ordering of ObjectFifos in MLIR generated by IRON.
- Added support for intra-tile ObjectFifos by treating them as shared-memory connections with memory-on-source.
