### PR TITLE
Move PnR flow to IRON; IRON generate ObjFifo-level MLIR with PnR routing hints

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPathToRouting.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathToRouting.cpp
@@ -125,7 +125,19 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
     }
   }
 
-  int getChannel(TileID tileId, WireBundle bundle, bool isSrc, CircuitPathOp pathOp) {
+  WireBundle getOppositeBundle(WireBundle bundle) {
+    switch (bundle) {
+      case WireBundle::North: return WireBundle::South;
+      case WireBundle::South: return WireBundle::North;
+      case WireBundle::East: return WireBundle::West;
+      case WireBundle::West: return WireBundle::East;
+      default:
+        llvm_unreachable("Invalid bundle for opposite");
+    }
+  }
+
+  int getChannel(TileID tileId, WireBundle bundle, bool isSrc, CircuitPathOp pathOp,
+                 const AIETargetModel &targetModel) {
     auto &chanMap = isSrc ? sbFreeChans.at(tileId).srcChans :
                             sbFreeChans.at(tileId).dstChans;
 
@@ -141,7 +153,11 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
     }
 
     int channel = *channels.begin();
-    channels.erase(channels.begin());
+    channels.erase(channel);
+    if (targetModel.isMemTile(tileId.col, tileId.row) && !isSrc) {
+      auto &otherChanMap = sbFreeChans.at(tileId).srcChans;
+      otherChanMap[getOppositeBundle(bundle)].erase(channel);
+    }
 
     return channel;
   }
@@ -187,7 +203,6 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
 
   void addConnection(OpBuilder &builder, Interconnect op, WireBundle inBundle,
                      int inIndex, WireBundle outBundle, int outIndex) const {
-
     Region &r = op.getConnections();
     Block &b = r.front();
     auto point = builder.saveInsertionPoint();
@@ -198,11 +213,11 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
 
     builder.restoreInsertionPoint(point);
 
-    LLVM_DEBUG(llvm::dbgs()
+    llvm::dbgs()
                << "\t\taddConnection() (" << op.colIndex() << ","
-               << op.rowIndex() << ") " << stringifyWireBundle(inBundle)
-               << inIndex << " -> " << stringifyWireBundle(outBundle)
-               << outIndex << "\n");
+               << op.rowIndex() << ") " << inBundle
+               << inIndex << " -> " << outBundle
+               << outIndex << "\n";
   }
 
   void runOnOperation() override {
@@ -223,32 +238,52 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
       WireBundle srcBundle = pathOp.getSourceBundle();
       int srcChannel = pathOp.getSourceChannel();
       std::vector<std::vector<TileID>> pathTiles = pathOp.getTilesAlongPath();
+      
+      auto srcTile = cast<TileOp>(pathOp.getSource().getDefiningOp());
+      TileID srcTileId = {srcTile.colIndex(), srcTile.rowIndex()};
+      llvm::dbgs() << "Processing pathOp with Src: " << srcTileId << "\n";
+      
+      auto firstInnerMemTileIndex = [&](const std::vector<TileID> &path) {
+        for (size_t i = 1; i + 1 < path.size(); i++) {  // skip src and dst
+          TileID t = path[i];
+          if (targetModel.isMemTile(t.col, t.row)) {
+            return static_cast<int>(i);
+          }
+        }
+        return std::numeric_limits<int>::max();
+      };
 
-      LLVM_DEBUG({
-        auto srcTile = cast<TileOp>(pathOp.getSource().getDefiningOp());
-        TileID srcTileId = {srcTile.colIndex(), srcTile.rowIndex()};
-        llvm::dbgs() << "Processing pathOp with Src: " << srcTileId << "\n";
+      std::vector<std::pair<std::vector<TileID>, int>> pathChanPairs;
+      for (size_t i = 0; i < pathTiles.size(); i++) {
+        pathChanPairs.emplace_back(pathTiles[i], pathOp.getDestChannels()[i]);
+      }
+
+      std::sort(pathChanPairs.begin(), pathChanPairs.end(),
+          [&](auto &a, auto &b) {
+            return firstInnerMemTileIndex(a.first) <
+                   firstInnerMemTileIndex(b.first);
       });
+
+      pathTiles.clear();
+      std::vector<int> destChannels;
+      for (auto &pc : pathChanPairs) {
+        pathTiles.push_back(std::move(pc.first));
+        destChannels.push_back(pc.second);
+      }
+
       for (size_t dst_i = 0; dst_i < pathOp.getDests().size(); dst_i++) {
-        auto dstTile = cast<TileOp>(pathOp.getDests()[dst_i].getDefiningOp());
-        TileID dstTileId = {dstTile.colIndex(), dstTile.rowIndex()};
+        TileID dstTileId = pathTiles[dst_i].back();
         WireBundle dstBundle = pathOp.getDestBundle();
-        int dstChannel = pathOp.getDestChannels()[dst_i];
+        int dstChannel = destChannels[dst_i];
 
-        LLVM_DEBUG({
-          auto srcTile = cast<TileOp>(pathOp.getSource().getDefiningOp());
-          TileID srcTileId = {srcTile.colIndex(), srcTile.rowIndex()};
-          TileID dstTileId = {dstTile.colIndex(), dstTile.rowIndex()};
-          llvm::dbgs() << "\tSrc: " << srcTileId << " -> "
+        llvm::dbgs() << "\tSrc: " << srcTileId << " -> "
                       << "Dst[" << dst_i << "]: " << dstTileId << "\n";
-        });
 
-        LLVM_DEBUG({
-          llvm::dbgs() << "\t\tPath: ";
+
+        llvm::dbgs() << "\t\tPath: ";
           for (const auto &hop : pathTiles[dst_i])
             llvm::dbgs() << hop << " ";
           llvm::dbgs() << "\n";
-        });
 
         // pathTiles is at least [src, dst], loop runs >= 1
         for (size_t i = 0; i < pathTiles[dst_i].size() - 1; i++) {
@@ -266,15 +301,39 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
               // if A is src sb, also set input port
               sbConfigs[tileA].addSrc(Port{srcBundle, srcChannel});
             }
-            // set output port for tile A
+
+            // Initialize input port for tile B
+            int bChannel = getChannel(tileB, bundleB, true, pathOp, targetModel);
+            pInB = Port{bundleB, bChannel};
+
             if (sbConfigs.find(tileA) == sbConfigs.end())
               pathOp.emitOpError("Setting output port for sb with missing input port")
                   << " at sb(" << tileA.col << ", " << tileA.row << ")";
-            else
-              sbConfigs[tileA].addDst(Port{bundleA, getChannel(tileA, bundleA, false, pathOp)});
 
-            // Initialize input port for tile B
-            pInB = Port{bundleB, getChannel(tileB, bundleB, true, pathOp)};
+            // set output port for tile A
+            if (targetModel.isMemTile(tileB.col, tileB.row) && bundleB != WireBundle::DMA) {
+              llvm::dbgs() << "\t\tInter-mem case: ";
+              auto &chanMap = sbFreeChans.at(tileA).dstChans;
+              if (chanMap.find(bundleA) == chanMap.end()) {
+                pathOp.emitOpError("Bundle ") << stringifyEnum(bundleA) << " not available"
+                    << " at sb (" << tileA.col << ", " << tileA.row << ")";
+              }
+              std::set<int> &channels = chanMap[bundleA];
+              if (channels.find(bChannel) != channels.end()) 
+                channels.erase(bChannel);
+              else {
+                pathOp.emitOpError("Channel ") << bChannel << " for bundle "
+                    << stringifyEnum(bundleA) << " at sb (" << tileA.col << ", "
+                    << tileA.row << ") already used";
+              }
+
+              sbConfigs[tileA].addDst(Port{bundleA, bChannel});
+            }
+            else {
+              sbConfigs[tileA].addDst(
+                  Port{bundleA, getChannel(tileA, bundleA, false, pathOp, targetModel)}
+              );
+            }
           }
           
           // set input port for tile B
@@ -285,7 +344,7 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
         sbConfigs[dstTileId].addDst(Port{dstBundle, dstChannel});
       }
     }
-    LLVM_DEBUG(llvm::dbgs() << "Building aie connections\n");
+    llvm::dbgs() << "Building AIE routing connections\n";
     OpBuilder builder = OpBuilder::atBlockTerminator(device.getBody());
     for (auto pathOp : device.getOps<CircuitPathOp>()) {
       auto srcTile = cast<TileOp>(pathOp.getSource().getDefiningOp());

--- a/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
@@ -29,19 +29,33 @@ struct AIEPlaceTilesPass : public AIEPlaceTilesBase<AIEPlaceTilesPass> {
     LLVM_DEBUG(llvm::dbgs() << "Number of tiles: " << tileOps.size() << "\n");
     auto fifoOps = llvm::to_vector(device.getOps<ObjectFifoCreateOp>());
     LLVM_DEBUG(llvm::dbgs() << "Number of FIFOs: " << fifoOps.size() << "\n");
-    for (size_t i = 0; i < tileOps.size(); i++) {
-      auto tileOp = tileOps[i];
-      auto node = input["nodes"][i];
 
-      int col = node["col_x"];
-      int row = node["row_y"];
+    for (const auto &node : input["nodes"]) {
+      int id = node["id"].get<int>();
 
-      tileOp.setCol(col);
-      tileOp.setRow(row);
+      // check bounds before indexing
+      if (id >= 0 && id < (int)tileOps.size()) {
+        TileOp tile = tileOps[id];
+        
+        int col = node["col_x"];
+        int row = node["row_y"];
+
+        tile.setCol(col);
+        tile.setRow(row);
+        LLVM_DEBUG(llvm::dbgs() << "Matched node id " << id << " -> TileOp at index " << id << "\n");
+      } 
+      else 
+        llvm::errs() << "Warning: node id " << id << " out of range\n";
     }
     LLVM_DEBUG(llvm::dbgs() << "Tiles placed successfully.\n");
+
     for (size_t i = 0; i < fifoOps.size(); i++) {
       auto fifoOp = fifoOps[i];
+      if (!input["nets"][i].contains("routing_info")) {
+        fifoOp.emitError("No routing_info key found in JSON for net " + 
+            std::to_string(input["nets"][i]["id"].get<int>()));
+        return;
+      }
       auto route_info = input["nets"][i]["routing_info"];
 
       if (route_info["connection_type"] == "circuit_switch") {

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -417,6 +417,8 @@ class object_fifo(ObjectFifoCreateOp):
         plio=None,
         padDimensions=None,
         disable_synchronization=None,
+        hop_tiles_ids=None,
+        via_shared_mem=None,
     ):
         self.datatype = try_convert_np_type_to_mlir_type(datatype)
         if not isinstance(consumerTiles, List):
@@ -447,6 +449,8 @@ class object_fifo(ObjectFifoCreateOp):
             padDimensions=padDimensions,
             disable_synchronization=disable_synchronization,
             initValues=initValues,
+            hop_tile_ids=hop_tiles_ids,
+            via_shared_mem=via_shared_mem,
         )
 
     def acquire(self, port, num_elem):

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -417,7 +417,7 @@ class object_fifo(ObjectFifoCreateOp):
         plio=None,
         padDimensions=None,
         disable_synchronization=None,
-        hop_tiles_ids=None,
+        hop_tile_ids=None,
         via_shared_mem=None,
     ):
         self.datatype = try_convert_np_type_to_mlir_type(datatype)
@@ -436,6 +436,22 @@ class object_fifo(ObjectFifoCreateOp):
                     init_val = array("i", e)
                 values.append(DenseElementsAttr.get(init_val, type=self.datatype))
             initValues = _arrayAttr(values, None)
+        if via_shared_mem is not None:
+            values = []
+            for e in via_shared_mem:
+                values.append(IntegerAttr.get(T.i32(), e))
+            via_shared_mem = _arrayAttr(values, None)
+        if hop_tile_ids is not None:
+            outer_values = []
+            for hop_path in hop_tile_ids:  # list[list[list[int]]]
+                mid_values = []
+                for coords in hop_path:  # list[list[int]]
+                    inner_values = []
+                    for val in coords:  # list[int]
+                        inner_values.append(IntegerAttr.get(T.i32(), val))
+                    mid_values.append(_arrayAttr(inner_values, None))
+                outer_values.append(_arrayAttr(mid_values, None))
+            hop_tile_ids = _arrayAttr(outer_values, None)
         super().__init__(
             sym_name=name,
             producerTile=producerTile,
@@ -449,7 +465,7 @@ class object_fifo(ObjectFifoCreateOp):
             padDimensions=padDimensions,
             disable_synchronization=disable_synchronization,
             initValues=initValues,
-            hop_tile_ids=hop_tiles_ids,
+            hop_tile_ids=hop_tile_ids,
             via_shared_mem=via_shared_mem,
         )
 

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -547,6 +547,7 @@ class ObjectFifoHandle(Resolvable):
         dims_to_stream: list[list[Sequence[int]]] | None = None,
         dims_from_stream: list[list[Sequence[int]]] | None = None,
         plio: bool = False,
+        p_depth: int | None = None,
     ) -> list[ObjectFifo]:
         """Split the data from an ObjectFifoConsumer handle by sending it to producers in N newly constructed ObjectFifos.
         Note this operation is only valid for ObjectFifoHandles of type consumer.
@@ -612,9 +613,11 @@ class ObjectFifoHandle(Resolvable):
                     plio=plio,
                 )
             )
-
         # Create link and set it as endpoints
-        subfifo_prods = [s.prod() for s in subfifos]
+        if p_depth:
+            subfifo_prods = [s.prod(p_depth) for s in subfifos]
+        else:
+            subfifo_prods = [s.prod() for s in subfifos]
         _ = ObjectFifoLink(self, subfifo_prods, placement, [], offsets)
         return subfifos
 
@@ -650,7 +653,10 @@ class ObjectFifoHandle(Resolvable):
             raise ValueError(f"Cannot forward a {self.handle_type} ObjectFifoHandle")
         if obj_type:
             obj_type = [obj_type]
+        p_depth = None
         if depth:
+            if self._depth != depth:
+                p_depth = self._depth
             depth = [depth]
         if name:
             name = [name]
@@ -660,7 +666,6 @@ class ObjectFifoHandle(Resolvable):
             dims_to_stream = [dims_to_stream]
         if dims_from_stream:
             dims_from_stream = [dims_from_stream]
-
         forward_fifo = self.split(
             [0],
             placement=placement,
@@ -670,6 +675,7 @@ class ObjectFifoHandle(Resolvable):
             dims_to_stream=dims_to_stream,
             dims_from_stream=dims_from_stream,
             plio=plio,
+            p_depth=p_depth,
         )
         return forward_fifo[0]
 

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -76,6 +76,9 @@ class ObjectFifo(Resolvable):
         self._prod: ObjectFifoHandle | None = None
         self._cons: list[ObjectFifoHandle] = []
         self._resolving = False
+        self._via_dma: bool = False
+        self._hop_tile_ids: list[list[list[int]]] | None = None
+        self._via_shared_mem: list[int] | None = None
 
     @classmethod
     def __get_index(cls) -> int:
@@ -267,6 +270,9 @@ class ObjectFifo(Resolvable):
                 dimensionsToStream=self._dims_to_stream,
                 dimensionsFromStreamPerConsumer=dims_from_stream_per_cons,
                 plio=self._plio,
+                via_DMA=self._via_dma,
+                via_shared_mem=self._via_shared_mem,
+                hop_tile_ids=self._hop_tile_ids,
             )
 
             if isinstance(self._prod.endpoint, ObjectFifoLink):

--- a/python/iron/device/device.py
+++ b/python/iron/device/device.py
@@ -159,18 +159,9 @@ class Device(Resolvable):
         loc: ir.Location | None = None,
         ip: ir.InsertionPoint | None = None,
     ) -> None:
-        if (t.col < 0) or (t.row < 0):
-            t.op = tile(
-                t.col,
-                t.row,
-                loc=loc,
-                ip=ip,
-                allocation_scheme=t.allocation_scheme,
-            )
-        else:
-            self._tiles[t.col][t.row].resolve(loc, ip, t.allocation_scheme)
-            t.op = self._tiles[t.col][t.row].op
 
+        self._tiles[t.col][t.row].resolve(loc, ip, t.allocation_scheme)
+        t.op = self._tiles[t.col][t.row].op
 
 class NPUBase(Device):
     """A base class which can be used to create other device specific classes.

--- a/python/iron/placers.py
+++ b/python/iron/placers.py
@@ -10,12 +10,75 @@ from abc import ABCMeta, abstractmethod
 import statistics
 import json
 import numpy as np
+import os
+from subprocess import Popen, PIPE, TimeoutExpired
+from dataclasses import dataclass
 
 from .device import Device
 from .runtime import Runtime, RuntimeEndpoint
 from .worker import Worker
 from .device import AnyComputeTile, AnyMemTile, AnyShimTile, Tile
 from .dataflow import ObjectFifoHandle, ObjectFifoLink, ObjectFifoEndpoint
+
+@dataclass
+class CommandResult:
+    cmd: str
+    cwd: str
+    env: dict
+    stdout: str
+    stderr: str
+    returncode: int
+    is_timed_out: bool
+
+    def ok(self):
+        return self.returncode == 0 and not self.is_timed_out
+
+    def check(self):
+        if not self.ok():
+            raise RuntimeError(
+                f"Command '{self.cmd}' (on directory '{self.cwd}' with env '{self.env}') "
+                f"failed with return code {self.returncode}.\n\n"
+                f"Stdout:\n{self.stdout}\n\nStderr:\n{self.stderr}"
+            )
+
+    def __repr__(self):
+        return (
+            f"CommandResult(cmd={self.cmd}, cwd={self.cwd}, returncode={self.returncode}, "
+            f"is_timed_out={self.is_timed_out},\nstdout={self.stdout},\nstderr={self.stderr},\nenv={self.env})"
+        )
+
+def read_text_file(file_path):
+    with open(file_path, "r") as f:
+        return f.read()
+
+
+def write_text_file(file_path, content):
+    with open(file_path, "w") as f:
+        f.write(content)
+
+def subprocess_run_cmd(cmd, cwd=None, env=None, timeout_sec=36000):
+    assert isinstance(cmd, str), "Command must be a string"
+    process = Popen(cmd, cwd=cwd, shell=True, stdout=PIPE, stderr=PIPE, env=env)
+
+    is_timed_out = False
+
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_sec)
+    except TimeoutExpired:
+        process.kill()
+        stdout, stderr = process.communicate()
+        is_timed_out = True
+        print(f"Command '{cmd}' timed out after {timeout_sec} seconds.")
+
+    return CommandResult(
+        cmd=cmd,
+        cwd=cwd,
+        env=env,
+        stdout=stdout.decode(),
+        stderr=stderr.decode(),
+        returncode=process.returncode,
+        is_timed_out=is_timed_out,
+    )
 
 
 class Placer(metaclass=ABCMeta):
@@ -41,7 +104,7 @@ class Placer(metaclass=ABCMeta):
         """
         ...
 
-class NullPlacer(Placer):
+class PnrPlacer(Placer):
     """
     TODO: Change placer name
     """
@@ -120,10 +183,26 @@ class NullPlacer(Placer):
         with open("netlist.json", "w") as f:
             json.dump(data, f, indent=2)
 
-        # --- Run placer subprocess here ---
+        
         # subprocess.run([...], check=True)
         breakpoint()
 
+        # --- Run placer subprocess here ---
+        pnr_args = "-n 200"
+        pnr_bin = os.path.expandvars("$NPU_PNR_BIN_DIR/placer")
+        assert os.path.exists(pnr_bin), f"PnR binary not found at {pnr_bin}"
+        pnr_cmd = str(
+            f"{pnr_bin} netlist.json "
+            "--output=placed.json "
+            "--route-summary=route_summary.json"
+        )
+        if pnr_args is not None:
+            pnr_cmd += f" {pnr_args}"
+        
+        cwd = os.getcwd()
+        pnr = subprocess_run_cmd(pnr_cmd, cwd=cwd)
+        pnr.check()
+        breakpoint()
         # Load placed netlist
         with open("placed.json", "r") as f:
             placed_data = json.load(f)

--- a/python/iron/placers.py
+++ b/python/iron/placers.py
@@ -11,6 +11,7 @@ import statistics
 import json
 import numpy as np
 import os
+import sys
 from subprocess import Popen, PIPE, TimeoutExpired
 from dataclasses import dataclass
 
@@ -104,14 +105,14 @@ class Placer(metaclass=ABCMeta):
         """
         ...
 
-class PnrPlacer(Placer):
+class SAPlacer(Placer):
     """
-    TODO: Change placer name
+    Simulated Annealing Placer
     """
 
-    def __init__(self):
+    def __init__(self, pnr_args: str = None):
         super().__init__()
-
+        self._pnr_args = pnr_args
     def make_placement(
         self,
         device: Device,
@@ -121,15 +122,6 @@ class PnrPlacer(Placer):
     ):
 
         data = {"nodes": [], "nets": [], "links": []}
-
-        # Mapping between handles/FIFOs and IDs
-        fifo_handle_ids = {ofh: idx for idx, ofh in enumerate(fifo_handles)}
-        id_to_fifo_handle = {idx: ofh for idx, ofh in enumerate(fifo_handles)}
-
-        # Build nodes
-        for idx, ofh in enumerate(fifo_handles):
-            t_type, row_y = self.get_node_info(ofh.tile)
-            data["nodes"].append({"id": idx, "type": t_type, "col_x": -1, "row_y": row_y})
         
         # Get FIFO list
         seen = set()
@@ -142,15 +134,18 @@ class PnrPlacer(Placer):
 
         fifo_ids = {of: idx for idx, of in enumerate(of_list)}
         id_to_fifo = {idx: of for idx, of in enumerate(of_list)}
+        eps_to_ids: dict[ObjectFifoEndpoint, int] = {}
+        ids_to_eps: dict[int, ObjectFifoEndpoint] = {}
 
         # Build nets
         for idx, of in enumerate(of_list):
-            src_node_id = fifo_handle_ids[of._prod]
-            dst_node_ids = [fifo_handle_ids[c] for c in of._cons]
+            src_node_id = self._get_or_assign_id(eps_to_ids, ids_to_eps, of._prod.endpoint)
+            dst_node_ids = [self._get_or_assign_id(eps_to_ids, ids_to_eps, c.endpoint) for c in of._cons]
             depths = of._get_depths()
             if not isinstance(depths, list):
                 depths = [depths]
-            bytes_per_depth = np.prod(of.shape) * of.dtype.itemsize
+            depths = [int(d) for d in depths]  # ensure plain ints
+            bytes_per_depth = int(np.prod(of.shape) * np.dtype(of.dtype).itemsize)
 
             data["nets"].append({
                 "net_id": idx,
@@ -160,6 +155,11 @@ class PnrPlacer(Placer):
                 "depths": depths,
                 "byte_size_per_depth": bytes_per_depth
             })
+
+        # Build nodes
+        for ep, n_id in eps_to_ids.items():
+            t_type, row_y = self._get_node_info(ep.tile)
+            data["nodes"].append({"id": n_id, "type": t_type, "col_x": -1, "row_y": row_y})
 
         # Build links
         link_set = set()
@@ -184,25 +184,21 @@ class PnrPlacer(Placer):
             json.dump(data, f, indent=2)
 
         
-        # subprocess.run([...], check=True)
-        breakpoint()
-
         # --- Run placer subprocess here ---
-        pnr_args = "-n 200"
         pnr_bin = os.path.expandvars("$NPU_PNR_BIN_DIR/placer")
         assert os.path.exists(pnr_bin), f"PnR binary not found at {pnr_bin}"
         pnr_cmd = str(
             f"{pnr_bin} netlist.json "
             "--output=placed.json "
-            "--route-summary=route_summary.json"
+            "--route-summary=route_summary.json "
         )
-        if pnr_args is not None:
-            pnr_cmd += f" {pnr_args}"
-        
+        if self._pnr_args is not None:
+            pnr_cmd += f" {self._pnr_args}"
+        print(f"Running pnr: {pnr_cmd}", file=sys.stderr)
         cwd = os.getcwd()
         pnr = subprocess_run_cmd(pnr_cmd, cwd=cwd)
         pnr.check()
-        breakpoint()
+        print("Finished pnr", file=sys.stderr)
         # Load placed netlist
         with open("placed.json", "r") as f:
             placed_data = json.load(f)
@@ -215,13 +211,14 @@ class PnrPlacer(Placer):
             if t is None:
                 t = Tile(*coord)
                 coord_to_tile[coord] = t
-            id_to_fifo_handle[node["id"]].endpoint.place(t)
-
+            ids_to_eps[node["id"]].place(t)
+        # assert every endpoint.tile is instance Tile
+        for ep, n_id in eps_to_ids.items():
+            if not isinstance(ep.tile, Tile):
+                raise ValueError(f"Endpoint {ep} was not placed by placer!")
         # Apply net placements and routing info
         for net in placed_data["nets"]:
             of = id_to_fifo[net["net_id"]]
-            if net["net_name"] != of.name:
-                raise ValueError("Placed netlist does not match original netlist!")
 
             routing = net["routing_info"]
             if routing["connection_type"] == "circuit_switch":
@@ -235,18 +232,38 @@ class PnrPlacer(Placer):
                 raise ValueError(f"Unknown connection type {routing['connection_type']}")
         # Place buffers for workers
         for worker in workers:
+            assert isinstance(worker.tile, Tile), f"Worker {worker} was not placed by placer!"
             for buffer in worker.buffers:
                 buffer.place(worker.tile)
 
-    def get_node_info(tile):
+    def _get_node_info(self, tile):
         if tile == AnyComputeTile:
             return "COMP", -1
         elif tile == AnyMemTile:
             return "MEM", 1
         elif tile == AnyShimTile:
             return "SHIM", 0
+        elif isinstance(tile, Tile):
+            if tile.row == 0:
+                return "SHIM", 0
+            elif tile.row == 1:
+                return "MEM", 1
+            else:
+                return "COMP", -1
         else:
-            raise ValueError("Unknown placeholder tile type." + str(tile))
+            raise ValueError("Unknown tile type." + str(tile))
+
+    def _get_or_assign_id(
+        self, 
+        endpoint_to_ids, 
+        ids_to_endpoints, 
+        endpoint
+    ):
+        if endpoint not in endpoint_to_ids:
+            new_id = len(endpoint_to_ids)
+            endpoint_to_ids[endpoint] = new_id
+            ids_to_endpoints[new_id] = endpoint
+        return endpoint_to_ids[endpoint]
 
 class SequentialPlacer(Placer):
     """SequentialPlacer is a simple implementation of a placer. The SequentialPlacer is so named

--- a/python/iron/placers.py
+++ b/python/iron/placers.py
@@ -8,6 +8,8 @@
 
 from abc import ABCMeta, abstractmethod
 import statistics
+import json
+import numpy as np
 
 from .device import Device
 from .runtime import Runtime, RuntimeEndpoint
@@ -41,9 +43,7 @@ class Placer(metaclass=ABCMeta):
 
 class NullPlacer(Placer):
     """
-    NullPlacer is a minimal placer that does not attempt
-    to optimize placement. It only allocates physical tiles
-    and keeps track of DMA channel usage.
+    TODO: Change placer name
     """
 
     def __init__(self):
@@ -54,234 +54,120 @@ class NullPlacer(Placer):
         device: Device,
         rt: Runtime,
         workers: list[Worker],
-        object_fifos: set[ObjectFifoHandle],
+        fifo_handles: list[ObjectFifoHandle],
     ):
-        comp_tiles: list[Tile] = []
-        shim_tiles: list[Tile] = []
-        mem_tiles: list[Tile] = []
 
-        channels_in: dict[Tile, int] = {}
-        channels_out: dict[Tile, int] = {}
+        data = {"nodes": [], "nets": [], "links": []}
 
-        # Place workers and update their channel usage
+        # Mapping between handles/FIFOs and IDs
+        fifo_handle_ids = {ofh: idx for idx, ofh in enumerate(fifo_handles)}
+        id_to_fifo_handle = {idx: ofh for idx, ofh in enumerate(fifo_handles)}
+
+        # Build nodes
+        for idx, ofh in enumerate(fifo_handles):
+            t_type, row_y = self.get_node_info(ofh.tile)
+            data["nodes"].append({"id": idx, "type": t_type, "col_x": -1, "row_y": row_y})
+        
+        # Get FIFO list
+        seen = set()
+        of_list = []
+        for ofh in fifo_handles:
+            fifo = ofh._object_fifo
+            if fifo not in seen:
+                seen.add(fifo)
+                of_list.append(fifo)
+
+        fifo_ids = {of: idx for idx, of in enumerate(of_list)}
+        id_to_fifo = {idx: of for idx, of in enumerate(of_list)}
+
+        # Build nets
+        for idx, of in enumerate(of_list):
+            src_node_id = fifo_handle_ids[of._prod]
+            dst_node_ids = [fifo_handle_ids[c] for c in of._cons]
+            depths = of._get_depths()
+            if not isinstance(depths, list):
+                depths = [depths]
+            bytes_per_depth = np.prod(of.shape) * of.dtype.itemsize
+
+            data["nets"].append({
+                "net_id": idx,
+                "net_name": of.name,
+                "src_id": src_node_id,
+                "dst_ids": dst_node_ids,
+                "depths": depths,
+                "byte_size_per_depth": bytes_per_depth
+            })
+
+        # Build links
+        link_set = set()
+        for of in of_list:
+            endpoints = of._get_endpoint(is_prod=True) + of._get_endpoint(is_prod=False)
+            for ep in endpoints:
+                if isinstance(ep, ObjectFifoLink):
+                    link_set.add(ep)
+        for link in link_set:
+            src_handles = link._srcs if isinstance(link._srcs, list) else [link._srcs]
+            dst_handles = link._dsts if isinstance(link._dsts, list) else [link._dsts]
+
+            src_net_ids = sorted({fifo_ids[h._object_fifo] for h in src_handles})
+            dst_net_ids = sorted({fifo_ids[h._object_fifo] for h in dst_handles})
+
+            data["links"].append({
+                "src_net_ids": src_net_ids,
+                "dst_net_ids": dst_net_ids
+            })
+
+        with open("netlist.json", "w") as f:
+            json.dump(data, f, indent=2)
+
+        # --- Run placer subprocess here ---
+        # subprocess.run([...], check=True)
+        breakpoint()
+
+        # Load placed netlist
+        with open("placed.json", "r") as f:
+            placed_data = json.load(f)
+
+        # Map coordinates to tiles
+        coord_to_tile: dict[tuple[int, int], Tile] = {}
+        for node in placed_data["nodes"]:
+            coord = (node["col_x"], node["row_y"])
+            t = coord_to_tile.get(coord)
+            if t is None:
+                t = Tile(*coord)
+                coord_to_tile[coord] = t
+            id_to_fifo_handle[node["id"]].endpoint.place(t)
+
+        # Apply net placements and routing info
+        for net in placed_data["nets"]:
+            of = id_to_fifo[net["net_id"]]
+            if net["net_name"] != of.name:
+                raise ValueError("Placed netlist does not match original netlist!")
+
+            routing = net["routing_info"]
+            if routing["connection_type"] == "circuit_switch":
+                of._via_dma = True
+                of._hop_tile_ids = routing["intermediates"]
+            elif routing["connection_type"] == "neighbor_sharing":
+                of._via_shared_mem = routing["share_directions"]
+            elif routing["connection_type"] == "intra_tile":
+                of._via_shared_mem = [-1]
+            else:
+                raise ValueError(f"Unknown connection type {routing['connection_type']}")
+        # Place buffers for workers
         for worker in workers:
-            if worker.tile == AnyComputeTile:
-                w_tile = Tile(-1, -1, logical=True)
-                worker.place(w_tile)
-                comp_tiles.append(w_tile)
-
             for buffer in worker.buffers:
                 buffer.place(worker.tile)
 
-        # Place ObjectFifo endpoints
-        fifos_to_process = list(object_fifos)
-        while fifos_to_process:
-            ofh = fifos_to_process.pop()
-            all_eps = ofh.all_of_endpoints()
-            ofh_eps = ofh._object_fifo._get_endpoint(is_prod=ofh._is_prod)
-            link_eps = [ofe for ofe in all_eps if isinstance(ofe, ObjectFifoLink)]
-            
-            # Place normal endpoints for this handle
-            for ofe in ofh_eps:
-                if isinstance(ofe, Worker):
-                    continue
-
-                if ofe.tile in (AnyMemTile, AnyShimTile):
-                    if isinstance(ofe, ObjectFifoLink):
-                        continue
-
-                    num_chans, link_chans = self._get_channel_reqs(ofe, ofh._is_prod)
-                    tiles_list, chans, other_chans = self._get_tile_alloc_lists(
-                        ofe,
-                        comp_tiles,
-                        mem_tiles,
-                        shim_tiles,
-                        channels_in,
-                        channels_out,
-                        ofh._is_prod,
-                    )
-
-                    self._place_endpoint(
-                        ofe,
-                        chans,
-                        other_chans,
-                        num_chans,
-                        link_chans,
-                        tiles_list,
-                        device,
-                        ofh._is_prod,
-                    )
-
-            # Place link endpoints for this handle
-            for ofl in link_eps:
-                if ofl.tile in (AnyMemTile, AnyComputeTile):
-                    num_chans, link_chans = self._get_channel_reqs(ofl, ofh._is_prod)
-                    tiles_list, chans, other_chans = self._get_tile_alloc_lists(
-                        ofl,
-                        comp_tiles,
-                        mem_tiles,
-                        shim_tiles,
-                        channels_in,
-                        channels_out,
-                        ofh._is_prod,
-                    )
-
-                    self._place_endpoint(
-                        ofl,
-                        chans,
-                        other_chans,
-                        num_chans,
-                        link_chans,
-                        tiles_list,
-                        device,
-                        ofh._is_prod,
-                    )
-
-            self.sort_by_overlap(fifos_to_process, ofh)
-
-    def _get_channel_reqs(self, ofe, is_prod):
-        """
-        Returns (primary_channels, secondary_channels).
-        Secondary channels are used bc links use channels
-        in both directions.
-        """
-        if isinstance(ofe, ObjectFifoLink):
-            if is_prod:
-                return len(ofe._srcs), len(ofe._dsts)
-            else:
-                return len(ofe._dsts), len(ofe._srcs)
-        return 1, 0
-
-    def _get_tile_alloc_lists(
-        self,
-        ofe: ObjectFifoEndpoint,
-        comp_tiles: list[Tile],
-        mem_tiles: list[Tile],
-        shim_tiles: list[Tile],
-        channels_in: dict[Tile, int],
-        channels_out: dict[Tile, int],
-        is_prod: bool,
-    ):
-        if ofe.tile == AnyMemTile:
-            return (
-                mem_tiles,
-                (channels_out if is_prod else channels_in),
-                (channels_in if is_prod else channels_out),
-            )
-        elif ofe.tile == AnyShimTile:
-            return (
-                shim_tiles,
-                (channels_in if is_prod else channels_out),
-                (channels_out if is_prod else channels_in),
-            )
-        elif ofe.tile == AnyComputeTile:
-            return (
-                comp_tiles,
-                (channels_out if is_prod else channels_in),
-                (channels_in if is_prod else channels_out),
-            )
+    def get_node_info(tile):
+        if tile == AnyComputeTile:
+            return "COMP", -1
+        elif tile == AnyMemTile:
+            return "MEM", 1
+        elif tile == AnyShimTile:
+            return "SHIM", 0
         else:
-            raise ValueError(f"Unknown tile type: {ofe.tile} for endpoint {ofe}")
-
-    def _update_channels(
-        self,
-        chans: dict[Tile, int],
-        tile: Tile,
-        num_req_chans: int,
-        device: Device,
-        is_prod: bool,
-        is_link: bool = False,
-        num_link_chans: int = 0,
-        link_chans: dict[Tile, int] = {},
-    ):
-        cur = chans.get(tile, 0)
-        if cur + num_req_chans > device.get_num_connections(tile, is_prod):
-            return False
-
-        if is_link:
-            other_cur = link_chans.get(tile, 0)
-            if other_cur + num_link_chans > device.get_num_connections(tile, not is_prod):
-                return False
-            link_chans[tile] = other_cur + num_link_chans
-
-        chans[tile] = cur + num_req_chans
-        return True
-
-    def _place_endpoint(
-        self,
-        ofe: ObjectFifoEndpoint,
-        chans: dict[Tile, int],
-        other_chans: dict[Tile, int],
-        num_req_chans: int,
-        num_link_chans: int,
-        tiles_list: list[Tile],
-        device: Device,
-        is_prod: bool,
-    ):
-        is_link = isinstance(ofe, ObjectFifoLink)
-        for p_tile in tiles_list:
-            if self._update_channels(
-                chans,
-                p_tile,
-                num_req_chans,
-                device,
-                is_prod,
-                is_link,
-                num_link_chans,
-                other_chans,
-            ):
-                ofe.place(p_tile)
-                return
-
-        # Create a new tile if no existing one works
-        if ofe.tile == AnyComputeTile:
-            p_tile = Tile(-1, -1, logical=True)
-        elif ofe.tile == AnyMemTile:
-            p_tile = Tile(-1, 1, logical=True)
-        else:  # AnyShimTile
-            p_tile = Tile(-1, 0, logical=True)
-
-        if self._update_channels(
-            chans,
-            p_tile,
-            num_req_chans,
-            device,
-            is_prod,
-            is_link,
-            num_link_chans,
-            other_chans,
-        ):
-            ofe.place(p_tile)
-            tiles_list.append(p_tile)
-        else:
-            raise ValueError(
-                f"Requested {'OUT' if is_prod else 'IN'} DMA channels "
-                f"exceed capacity for tile {p_tile} {id(p_tile)}"
-            )
-
-    def sort_by_overlap(
-        self,
-        fifo_handles: list[ObjectFifoHandle],
-        ref_handle: ObjectFifoHandle,
-    ):  
-        '''
-        Utility function that sorts net processing so nets with
-        shared endpoints are more likely to share mem/shim tiles.
-        '''
-        # Filter RuntimeEndpoint due to __eq__ overwrite
-        ref_eps = {
-            ep for ep in ref_handle.all_of_endpoints()
-            if not isinstance(ep, RuntimeEndpoint)
-        }
-        fifo_handles.sort(
-            key=lambda h: len(
-                ref_eps & {
-                    ep for ep in h.all_of_endpoints()
-                    if not isinstance(ep, RuntimeEndpoint)
-                }
-            ),
-            reverse=True,
-        )       
+            raise ValueError("Unknown placeholder tile type." + str(tile))
 
 class SequentialPlacer(Placer):
     """SequentialPlacer is a simple implementation of a placer. The SequentialPlacer is so named

--- a/python/iron/program.py
+++ b/python/iron/program.py
@@ -12,7 +12,7 @@ from ..dialects.aie import device, tile
 
 from .device import Device
 from .runtime import Runtime
-from .placers import Placer, NullPlacer
+from .placers import Placer
 from .resolvable import Resolvable
 
 # import aie.utils.trace as trace_utils

--- a/python/iron/program.py
+++ b/python/iron/program.py
@@ -64,18 +64,11 @@ class Program:
                     )
 
                 # Collect all tiles
-                if isinstance(placer, NullPlacer):
-                    all_tiles = set()
-                    for w in self._rt.workers:
-                        all_tiles.add(w.tile)   
-                    for f in all_fifos:
-                        all_tiles.update(e.tile for e in f.all_of_endpoints())
-                else:
-                    all_tiles = []
-                    for w in self._rt.workers:
-                        all_tiles.append(w.tile)
-                    for f in all_fifos:
-                        all_tiles.extend([e.tile for e in f.all_of_endpoints()])
+                all_tiles = []
+                for w in self._rt.workers:
+                    all_tiles.append(w.tile)
+                for f in all_fifos:
+                    all_tiles.extend([e.tile for e in f.all_of_endpoints()])
                     
                 # Resolve tiles
                 for t in all_tiles:

--- a/python/iron/runtime/endpoint.py
+++ b/python/iron/runtime/endpoint.py
@@ -20,10 +20,5 @@ class RuntimeEndpoint(ObjectFifoEndpoint):
     def __init__(self, placement: PlacementTile) -> RuntimeEndpoint:
         super().__init__(placement)
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, RuntimeEndpoint):
-            return NotImplemented
-        return self.tile == other.tile
-
     def __str__(self) -> str:
         return f"RuntimeEndpoint({self.tile})"


### PR DESCRIPTION
- Added python bindings to set routing hints in IRON.
- Enabled IRON `.forward` to set different depths between producer and consumer.
- SAPlacer runs PnR flow to generate placement with routing hints.
- Fixed routing bug with routes that go from Shim to Comp and skip Mems.