### PR TITLE
Update Routing to support Mem tile switchbox requirement

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPathToRouting.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathToRouting.cpp
@@ -15,24 +15,46 @@ using SwitchConfig = struct SwitchConfig {
   std::vector<Port> srcs;
   std::vector<Port> dsts;
 
-  void addSrc(Port src) {
-    srcs.push_back(src);
-  }
-
-  void addDst(Port dst) {
-    dsts.push_back(dst);
-  }
+  void addSrc(Port src) {srcs.push_back(src); }
+  void addDst(Port dst) {dsts.push_back(dst); }
 };
 
 using SwitchConfigs = std::map<TileID, SwitchConfig>;
 
 // Track channel usage for each switchbox
 using SwitchFreeChans = struct SwitchFreeChans {
-  std::map<WireBundle, std::set<int>> srcChans;
-  std::map<WireBundle, std::set<int>> dstChans;
+  std::map<WireBundle, std::set<int>> availSrcChans;
+  std::map<WireBundle, std::set<int>> availDstChans;
 };
 
 using Interconnects = std::map<std::pair<TileID, TileID>, Port>;
+
+struct HopInfo {
+  TileID tile;
+  HopInfo *prevInfo = nullptr;
+  std::vector<HopInfo*> nextInfos;
+  int dstForPath = -1; // -1 = not a dst, otherwise index of path
+  std::optional<std::pair<WireBundle, int>> srcPort;
+  DenseMap<WireBundle, int> dstChans;
+};
+
+struct Key {
+  size_t idx;
+  TileID tile;
+
+  bool operator==(const Key &other) const {
+      return idx == other.idx && tile == other.tile;
+  }
+};
+
+struct KeyHash {
+  size_t operator()(const Key &k) const noexcept {
+    size_t h1 = std::hash<size_t>{}(k.idx);
+    size_t h2 = std::hash<int>{}(k.tile.col);
+    size_t h3 = std::hash<int>{}(k.tile.row);
+    return h1 ^ (h2 << 1) ^ (h3 << 2);
+  }
+};
 
 struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> {
   llvm::DenseMap<TileID, TileOp> coordToTile;
@@ -63,8 +85,8 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
           for (int channel = 0; channel < channels; channel++) {
             channelSet.insert(channel);
           }
-          
-          sbFreeChans[tileId].srcChans[bundle] = channelSet;
+
+          sbFreeChans[tileId].availSrcChans[bundle] = channelSet;
           channelSet.clear();
 
           // get all ports out of current switchbox
@@ -76,7 +98,7 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
           for (int channel = 0; channel < channels; channel++) {
             channelSet.insert(channel);
           }
-          sbFreeChans[tileId].dstChans[bundle] = channelSet;
+          sbFreeChans[tileId].availDstChans[bundle] = channelSet;
         }
       }
     }
@@ -107,22 +129,17 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
       coordToShimMux[{col, row}] = shimmuxOp;
     }
   }
+  
+  // returns direction to go from "from" tile to "to" tile
+  WireBundle getWireBundleToTo(TileID from, TileID to) {
+    int dCol = to.col - from.col;
+    int dRow = to.row - from.row;
 
-  // Function to get wire bundles, returns wire bundle pair {a, b}
-  std::pair<WireBundle, WireBundle> getWireBundles(TileID a, TileID b) {
-    if (a.col == b.col - 1) {
-      return {WireBundle::East, WireBundle::West};
-    } else if (a.col == b.col + 1) {
-      return {WireBundle::West, WireBundle::East};
-    } else if (a.row == b.row - 1) {
-      return {WireBundle::North, WireBundle::South};
-    } else if (a.row == b.row + 1) {
-      return {WireBundle::South, WireBundle::North};
-    } else {
-      llvm::errs() << "Tiles: " << a << " and " << b << 
-          " not adjacent, could not acquire wire bundles\n";
-      return {};
-    }
+    if (dCol == 0 && dRow > 0) return WireBundle::North;  
+    if (dCol == 0 && dRow < 0) return WireBundle::South;  
+    if (dRow == 0 && dCol > 0) return WireBundle::East;  
+    if (dRow == 0 && dCol < 0) return WireBundle::West;
+    llvm_unreachable("Tiles not adjacent");  
   }
 
   WireBundle getOppositeBundle(WireBundle bundle) {
@@ -134,32 +151,6 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
       default:
         llvm_unreachable("Invalid bundle for opposite");
     }
-  }
-
-  int getChannel(TileID tileId, WireBundle bundle, bool isSrc, CircuitPathOp pathOp,
-                 const AIETargetModel &targetModel) {
-    auto &chanMap = isSrc ? sbFreeChans.at(tileId).srcChans :
-                            sbFreeChans.at(tileId).dstChans;
-
-    if (chanMap.find(bundle) == chanMap.end()) {
-      pathOp.emitOpError("Bundle ") << stringifyEnum(bundle) << " not available"
-            << " at sb (" << tileId.col << ", " << tileId.row << ")";
-    }
-
-    std::set<int> &channels = chanMap[bundle];
-    if (channels.empty()) {
-      pathOp.emitOpError("Exceeded channels for bundle ") << stringifyEnum(bundle)
-          << " at sb: (" << tileId.col << ", " << tileId.row << ")";
-    }
-
-    int channel = *channels.begin();
-    channels.erase(channel);
-    if (targetModel.isMemTile(tileId.col, tileId.row) && !isSrc) {
-      auto &otherChanMap = sbFreeChans.at(tileId).srcChans;
-      otherChanMap[getOppositeBundle(bundle)].erase(channel);
-    }
-
-    return channel;
   }
 
   TileOp getTile(OpBuilder &builder, int col, int row) {
@@ -220,6 +211,51 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
                << outIndex << "\n";
   }
 
+  void setFlatPaths(CircuitPathOp op, std::vector<std::vector<HopInfo*>> &flatPaths,
+                    std::vector<std::unique_ptr<HopInfo>> &storage,
+                    std::unordered_map<Key, HopInfo*, KeyHash> &hopCache) {
+    size_t numPaths = op.getTilesAlongPath().size();
+    std::vector<std::vector<TileID>> pathTiles = op.getTilesAlongPath();
+    for (size_t pIdx = 0; pIdx < numPaths; pIdx++) {
+      std::vector<TileID> &path = pathTiles[pIdx];
+      HopInfo *prev = nullptr;
+
+      for (size_t j = 0; j < path.size(); ++j) {
+        TileID tile = path[j];
+        bool dst = (j + 1 == path.size());
+
+        Key key{j, tile};
+        HopInfo *hi = nullptr;
+        auto it = hopCache.find(key);
+        if (it != hopCache.end()) {
+          hi = it->second;
+        } else {
+          storage.push_back(std::make_unique<HopInfo>());
+          hi = storage.back().get();
+          hi->tile = tile;
+          hi->nextInfos.resize(numPaths, nullptr);
+          hopCache[key] = hi;
+          flatPaths[j].push_back(hi); // traversal by hop
+        }
+        hi->prevInfo = prev;
+
+        // First hop: all paths share same input bundle/channel
+        if (j == 0) 
+          hi->srcPort = std::make_pair(op.getSourceBundle(), op.getSourceChannel());
+
+        // Destination hop: per-path output bundle/channel
+        if (dst) {
+          if (hi->dstForPath != -1)
+            llvm_unreachable("One circuit path cannot have two destinations at same tile");
+          hi->dstForPath = (int)pIdx;
+          hi->dstChans[op.getDestBundle()] = op.getDestChannels()[pIdx];
+        }
+        if (prev) prev->nextInfos[pIdx] = hi;
+        prev = hi;
+      }
+    }
+  }
+
   void runOnOperation() override {
     DeviceOp device = getOperation();
     const AIETargetModel &targetModel = device.getTargetModel();
@@ -232,118 +268,191 @@ struct AIEPathToRoutingPass : public AIEPathToRoutingBase<AIEPathToRoutingPass> 
     // Set up switchbox configs and interconnects for each CircuitPathOp
     //===------------------------------------------------------------------===//
     for (auto pathOp : device.getOps<CircuitPathOp>()) {
-      Interconnects interconnects;
-      SwitchConfigs &sbConfigs = sbConfigList[pathOp];
-
-      WireBundle srcBundle = pathOp.getSourceBundle();
-      int srcChannel = pathOp.getSourceChannel();
-      std::vector<std::vector<TileID>> pathTiles = pathOp.getTilesAlongPath();
-      
+      // Debug //
       auto srcTile = cast<TileOp>(pathOp.getSource().getDefiningOp());
-      TileID srcTileId = {srcTile.colIndex(), srcTile.rowIndex()};
-      llvm::dbgs() << "Processing pathOp with Src: " << srcTileId << "\n";
-      
-      auto firstInnerMemTileIndex = [&](const std::vector<TileID> &path) {
-        for (size_t i = 1; i + 1 < path.size(); i++) {  // skip src and dst
-          TileID t = path[i];
-          if (targetModel.isMemTile(t.col, t.row)) {
-            return static_cast<int>(i);
-          }
-        }
-        return std::numeric_limits<int>::max();
-      };
-
-      std::vector<std::pair<std::vector<TileID>, int>> pathChanPairs;
-      for (size_t i = 0; i < pathTiles.size(); i++) {
-        pathChanPairs.emplace_back(pathTiles[i], pathOp.getDestChannels()[i]);
-      }
-
-      std::sort(pathChanPairs.begin(), pathChanPairs.end(),
-          [&](auto &a, auto &b) {
-            return firstInnerMemTileIndex(a.first) <
-                   firstInnerMemTileIndex(b.first);
-      });
-
-      pathTiles.clear();
-      std::vector<int> destChannels;
-      for (auto &pc : pathChanPairs) {
-        pathTiles.push_back(std::move(pc.first));
-        destChannels.push_back(pc.second);
-      }
-
+      llvm::dbgs() << "Routing Src: " << "(" << srcTile.colIndex() << "," << srcTile.rowIndex() << ") ";
       for (size_t dst_i = 0; dst_i < pathOp.getDests().size(); dst_i++) {
-        TileID dstTileId = pathTiles[dst_i].back();
-        WireBundle dstBundle = pathOp.getDestBundle();
-        int dstChannel = destChannels[dst_i];
+        auto dstTile = cast<TileOp>(pathOp.getDests()[dst_i].getDefiningOp());
+        if (dst_i != 0) llvm::dbgs() << "                   ";
+        llvm::dbgs() << "-> (" << dstTile.colIndex() << "," << dstTile.rowIndex() << ") | Path: ";
+        auto path = pathOp.getTilesAlongPath()[dst_i];
+        for (auto &tile : path) {
+          llvm::dbgs() << " (" << tile.col << "," << tile.row << ") ";
+        }
+        llvm::dbgs() << "\n";
+      }
+      /////////////////////////////////
+      size_t numPaths = pathOp.getTilesAlongPath().size();
+      size_t maxDepth = 0;
+      for (auto &path : pathOp.getTilesAlongPath())
+          maxDepth = std::max(maxDepth, path.size());
 
-        llvm::dbgs() << "\tSrc: " << srcTileId << " -> "
-                      << "Dst[" << dst_i << "]: " << dstTileId << "\n";
-
-
-        llvm::dbgs() << "\t\tPath: ";
-          for (const auto &hop : pathTiles[dst_i])
-            llvm::dbgs() << hop << " ";
-          llvm::dbgs() << "\n";
-
-        // pathTiles is at least [src, dst], loop runs >= 1
-        for (size_t i = 0; i < pathTiles[dst_i].size() - 1; i++) {
-          const auto &tileA = pathTiles[dst_i][i];
-          const auto &tileB = pathTiles[dst_i][i + 1];
-
-          auto [bundleA, bundleB] = getWireBundles(tileA, tileB);
-          auto [it, newInsert] = interconnects.try_emplace({tileA, tileB}, Port{});
-          Port& pInB = it->second;
-
-          // If new interconnect, initialize ports on both tiles,
-          // else reuse first tile's port (multicast)
-          if (newInsert) {
-            if (i == 0) {
-              // if A is src sb, also set input port
-              sbConfigs[tileA].addSrc(Port{srcBundle, srcChannel});
+      std::vector<std::unique_ptr<HopInfo>> storage;
+      std::unordered_map<Key, HopInfo*, KeyHash> hopCache;
+      std::vector<std::vector<HopInfo*>> flatPaths(maxDepth);  // outer vector = hop index
+      setFlatPaths(pathOp, flatPaths, storage, hopCache);
+      
+      for (size_t h = 0; h < maxDepth; h++) {
+        for (auto &hi : flatPaths[h]) {
+          //debug
+          // print hopinfo
+          llvm::dbgs() << "\tHop " << h << ":\n";
+          for (auto &hi : flatPaths[h]) {
+            llvm::dbgs() << "\t\tTile (" << hi->tile.col << "," << hi->tile.row << ") ";
+            if (hi->prevInfo)
+              llvm::dbgs() << " prev: (" << hi->prevInfo->tile.col << "," << hi->prevInfo->tile.row << ") ";
+            else
+              llvm::dbgs() << " prev: (null) ";
+            llvm::dbgs() << " nexts: ";
+            for (auto *n : hi->nextInfos) {
+              if (n)
+                llvm::dbgs() << "(" << n->tile.col << "," << n->tile.row << ") ";
+              else
+                llvm::dbgs() << "(null) ";
             }
-
-            // Initialize input port for tile B
-            int bChannel = getChannel(tileB, bundleB, true, pathOp, targetModel);
-            pInB = Port{bundleB, bChannel};
-
-            if (sbConfigs.find(tileA) == sbConfigs.end())
-              pathOp.emitOpError("Setting output port for sb with missing input port")
-                  << " at sb(" << tileA.col << ", " << tileA.row << ")";
-
-            // set output port for tile A
-            if (targetModel.isMemTile(tileB.col, tileB.row) && bundleB != WireBundle::DMA) {
-              llvm::dbgs() << "\t\tInter-mem case: ";
-              auto &chanMap = sbFreeChans.at(tileA).dstChans;
-              if (chanMap.find(bundleA) == chanMap.end()) {
-                pathOp.emitOpError("Bundle ") << stringifyEnum(bundleA) << " not available"
-                    << " at sb (" << tileA.col << ", " << tileA.row << ")";
-              }
-              std::set<int> &channels = chanMap[bundleA];
-              if (channels.find(bChannel) != channels.end()) 
-                channels.erase(bChannel);
-              else {
-                pathOp.emitOpError("Channel ") << bChannel << " for bundle "
-                    << stringifyEnum(bundleA) << " at sb (" << tileA.col << ", "
-                    << tileA.row << ") already used";
-              }
-
-              sbConfigs[tileA].addDst(Port{bundleA, bChannel});
+            if (hi->srcPort.has_value()) {
+              auto [wb, ch] = hi->srcPort.value();
+              llvm::dbgs() << " srcPort: " << stringifyEnum(wb) << ch << " ";
             }
-            else {
-              sbConfigs[tileA].addDst(
-                  Port{bundleA, getChannel(tileA, bundleA, false, pathOp, targetModel)}
-              );
+            llvm::dbgs() << " dstForPath: " << hi->dstForPath << " ";
+            llvm::dbgs() << " dstChans: ";
+            for (auto &[wb, ch] : hi->dstChans) {
+              llvm::dbgs() << stringifyEnum(wb) << ch << " ";
+            }
+            llvm::dbgs() << "\n";
+          }
+          // end debug
+
+          // start with input bundle and channel
+          HopInfo *prev = hi->prevInfo;
+          WireBundle srcWB;
+          int srcChan;
+          if (h == 0) {
+            assert (hi->srcPort.has_value());
+            std::tie(srcWB, srcChan) = hi->srcPort.value();
+          }
+          else {
+            srcWB = getWireBundleToTo(hi->tile, prev->tile);
+            auto it = prev->dstChans.find(getOppositeBundle(srcWB));
+            if (it == prev->dstChans.end()) {
+              pathOp.emitOpError("Previous tile (")
+                  << prev->tile.col << "," << prev->tile.row
+                  << ") was not assigned an outCh for bundle "
+                  << stringifyEnum(getOppositeBundle(srcWB)) << " to current tile ("
+                  << hi->tile.col << "," << hi->tile.row << ")";
+              return signalPassFailure();
+            }
+            srcChan = it->second;
+          }
+          // // sanity check last outCh is available as inCh
+          // auto &srcFree = sbFreeChans[hi->tile].availSrcChans[srcWB];
+          // if (srcFree.count(srcChan) == 0) {
+          //   pathOp.emitOpError("Sanity: Required inCh ") << srcChan << " for bundle "
+          //       << stringifyEnum(srcWB) << " at tile ("
+          //       << hi->tile.col << "," << hi->tile.row << ") not available";
+          //   return signalPassFailure();
+          // }
+          
+          bool isMem = targetModel.isMemTile(hi->tile.col, hi->tile.row);
+          // Work on output channels
+          if (isMem && srcWB != WireBundle::DMA) {
+            // mem tile: out channels must be same as in channel
+            int dstChan = srcChan;
+            std::set<TileID> examinedTiles;
+            for (size_t pIdx = 0; pIdx < numPaths; pIdx++) {
+              if ((int)pIdx == hi->dstForPath) continue;
+              if (hi->nextInfos[pIdx]) {
+                TileID nextTile = hi->nextInfos[pIdx]->tile;
+                if (examinedTiles.count(nextTile)) continue;
+                examinedTiles.insert(nextTile);
+                WireBundle dstWB = getWireBundleToTo(hi->tile, nextTile);
+                auto &dstFree = sbFreeChans[hi->tile].availDstChans[dstWB];
+                if (dstFree.count(dstChan) == 0) {
+                  pathOp.emitOpError("isNonSrcMem: Required outCh ") << dstChan << " for bundle "
+                      << stringifyEnum(dstWB) << " at tile ("
+                      << hi->tile.col << "," << hi->tile.row << ") not available";
+                  return signalPassFailure();
+                }
+                auto &nextSrcFree = sbFreeChans[hi->nextInfos[pIdx]->tile]
+                                        .availSrcChans[getOppositeBundle(dstWB)];
+                if (nextSrcFree.count(dstChan) == 0) {
+                  pathOp.emitOpError("isNonSrcMem: Required inCh ") << dstChan << " for bundle "
+                      << stringifyEnum(getOppositeBundle(dstWB)) << " at tile ("
+                      << nextTile.col << "," << nextTile.row << ") not available";
+                  return signalPassFailure();
+                }
+                hi->dstChans[dstWB] = dstChan;
+              } 
+            }
+          } else {
+            // non-mem tile or mem tile as source tile: out channels can be different
+            // if next hop is a mem tile and it's not a dst, we need to consider
+            // intersect outCh, nextInCh, nextOutCh
+            // otherwise intersect outCh, nextInCh
+            std::set<TileID> examinedTiles;
+            for (size_t pIdx = 0; pIdx < numPaths; pIdx++) {
+              if ((int)pIdx == hi->dstForPath) continue;
+              if (hi->nextInfos[pIdx]) {
+                TileID nextTile = hi->nextInfos[pIdx]->tile;
+                bool last = std::all_of(hi->nextInfos[pIdx]->nextInfos.begin(), hi->nextInfos[pIdx]->nextInfos.end(),
+                                        [&](HopInfo *n) { return n == nullptr; });
+                if (!last && hi->nextInfos[pIdx]->dstForPath == (int)pIdx) continue;
+                WireBundle dstWB = getWireBundleToTo(hi->tile, nextTile);
+                auto &dstFree = sbFreeChans[hi->tile].availDstChans[dstWB];
+                auto &nextSrcFree = sbFreeChans[nextTile].availSrcChans[getOppositeBundle(dstWB)];
+                std::set<int> intersection;
+                std::set_intersection(dstFree.begin(), dstFree.end(),
+                                      nextSrcFree.begin(), nextSrcFree.end(),
+                                      std::inserter(intersection, intersection.begin()));
+                if (intersection.empty()) {
+                  pathOp.emitOpError("No available outCh for bundle ")
+                      << stringifyEnum(dstWB) << " at tile ("
+                      << hi->tile.col << "," << hi->tile.row << ") to next tile ("
+                      << nextTile.col << "," << nextTile.row << ")";
+                  return signalPassFailure();
+                }
+                // If next hop is a mem tile and it's not the dst of that path,
+                // further intersect with next hop's outCh`
+                if (targetModel.isMemTile(nextTile.col, nextTile.row) && 
+                    hi->nextInfos[pIdx]->dstForPath != (int)pIdx) {
+                  std::set<int> tmp;
+                  auto &nextDstFree = sbFreeChans[nextTile].availDstChans[dstWB];
+                  std::set_intersection(intersection.begin(), intersection.end(),
+                                        nextDstFree.begin(), nextDstFree.end(),
+                                        std::inserter(tmp, tmp.begin()));
+                  intersection = std::move(tmp);
+                  if (intersection.empty()) {
+                    pathOp.emitOpError("No available outCh for bundle ")
+                        << stringifyEnum(dstWB) << " at tile ("
+                        << hi->tile.col << "," << hi->tile.row << ") to next tile ("
+                        << nextTile.col << "," << nextTile.row << ")"
+                        << " because outCh unavailable at next tile";
+                    return signalPassFailure();
+                  }
+                }
+                int dstChan = *intersection.begin();
+                hi->dstChans[dstWB] = dstChan;
+              }
             }
           }
-          
-          // set input port for tile B
-          sbConfigs[tileB].addSrc(pInB);
+          // mark tile srcChan as used
+          auto &srcFree = sbFreeChans[hi->tile].availSrcChans[srcWB];
+          srcFree.erase(srcChan);
+          // Add switchbox config
+          for (auto &[dstWB, dstChan] : hi->dstChans) {
+            sbConfigList[pathOp][hi->tile].addSrc(Port{srcWB, srcChan});
+            sbConfigList[pathOp][hi->tile].addDst(Port{dstWB, dstChan});
+            llvm::dbgs() << "\t\tAdded config at (" << hi->tile.col << "," << hi->tile.row
+                         << ") " << stringifyEnum(srcWB) << srcChan << " -> " 
+                         << stringifyEnum(dstWB) << dstChan << "\n";
+            // mark tile dstChan as used
+            auto &dstFree = sbFreeChans[hi->tile].availDstChans[dstWB];
+            dstFree.erase(dstChan);
+          }
         }
-
-        // set output port for dst tile
-        sbConfigs[dstTileId].addDst(Port{dstBundle, dstChannel});
       }
     }
+
     llvm::dbgs() << "Building AIE routing connections\n";
     OpBuilder builder = OpBuilder::atBlockTerminator(device.getBody());
     for (auto pathOp : device.getOps<CircuitPathOp>()) {


### PR DESCRIPTION
- Routing through Mem requires matching channels on source and destination if not using WireBundle::DMA.