### PR TITLE
Bring in packet switched lowering support from main repo

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1675,18 +1675,29 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shim_dma_allocation", [HasParent<"DeviceOp
         AIEI64Attr:$channel_index,
         AIEI64Attr:$col,
         // If this is set we are using the PLIO in this ShimTile
-        DefaultValuedAttr<BoolAttr, "false">:$plio
+        DefaultValuedAttr<BoolAttr, "false">:$plio,
+        OptionalAttr<PacketInfoAttr>:$packet
   );
 
   let results = (outs);
 
   let assemblyFormat = [{
-    $sym_name `(` $channel_dir `,` $channel_index `,` $col `)` attr-dict
+    $sym_name `(` $channel_dir `,` $channel_index `,` $col (`,` $packet^)? `)` attr-dict
   }];
 
   let extraClassDeclaration = [{
     static ::xilinx::AIE::ShimDMAAllocationOp getForSymbol(::xilinx::AIE::DeviceOp device, ::llvm::StringRef symbol);
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::StringRef":$sym_name, "DMAChannelDir":$dir, "int":$channel_index,
+               "int":$col, "bool":$plio), [{
+      build($_builder, $_state, ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), sym_name), 
+            DMAChannelDirAttr::get(odsBuilder.getContext(), dir),
+            $_builder.getI64IntegerAttr(channel_index), 
+            $_builder.getI64IntegerAttr(col), $_builder.getBoolAttr(plio), nullptr);
+    }]>
+  ];
 }
 
 def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]> {

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -263,7 +263,9 @@ def AIEObjectFifoStatefulTransform : Pass<"aie-objectFifo-stateful-transform", "
 
   let options = [
     Option<"clDynamicObjectFifos", "dynamic-objFifos", "bool", /*default=*/"false", 
-    "Flag to enable dynamic object fifo lowering in cores instead of loop unrolling.">
+    "Flag to enable dynamic object fifo lowering in cores instead of loop unrolling.">,
+    Option<"clPacketSwObjectFifos", "packet-sw-objFifos", "bool", /*default=*/"false",
+    "Flag to enable aie.packetflow lowering from objectfifos.">,
   ];
 }
 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -880,7 +880,8 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSe
         DMAChannelDir:$direction,
         I32Attr:$channel,
         DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,
-        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
+        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count,
+        OptionalAttr<PacketInfoAttr>:$packet
   );
 
   let regions = (
@@ -888,7 +889,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSe
   );
 
   let assemblyFormat = [{
-    `(` $tile `,` $direction `,` $channel `)` regions attr-dict
+    `(` $tile `,` $direction `,` $channel (`,` $packet^)? `)` regions attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -903,6 +904,16 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSe
 
   let hasVerifier = 1;
   let hasCanonicalizeMethod = 1;
+
+  let builders = [
+    OpBuilder<(ins "::mlir::Type":$result, "mlir::Value":$tile, "xilinx::AIE::DMAChannelDir":$dir, "int":$channel_index,
+               "bool":$token, "int":$repeat), [{
+      build($_builder, $_state, result, tile,
+            xilinx::AIE::DMAChannelDirAttr::get(odsBuilder.getContext(), dir),
+            $_builder.getI32IntegerAttr(channel_index), $_builder.getBoolAttr(token),
+            $_builder.getI32IntegerAttr(repeat), nullptr);
+    }]>
+  ];
 }
 
 def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasParent<"RuntimeSequenceOp">]>, Results<(outs Index:$result)> {

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -525,11 +525,14 @@ struct AIEObjectFifoStatefulTransformPass
   void createBd(OpBuilder &builder, LockOp acqLock, int acqMode,
                 LockAction acqLockAction, LockOp relLock, int relMode,
                 MyOp buff, int offset, int len, Block *succ,
-                BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr padDimensions) {
+                BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr padDimensions,
+                std::optional<PacketInfoAttr> bdPacket) {
     if (acqLock)
       builder.create<UseLockOp>(builder.getUnknownLoc(), acqLock, acqLockAction,
                                 acqMode);
-
+    if (bdPacket)
+      builder.create<DMABDPACKETOp>(builder.getUnknownLoc(), bdPacket->getPktType(),
+                                    bdPacket->getPktId());
     if (!dims.getValue().empty() && padDimensions) {
       builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len, dims,
                               padDimensions);
@@ -553,6 +556,7 @@ struct AIEObjectFifoStatefulTransformPass
                      DMAChannelDir channelDir, size_t lockIndex, Block *succ,
                      BDDimLayoutArrayAttr dims,
                      BDPadLayoutArrayAttr padDimensions,
+                     std::optional<PacketInfoAttr> bdPacket,
                      bool distribOrJoin = false) {
     LockOp acqLock;
     LockOp relLock;
@@ -586,26 +590,27 @@ struct AIEObjectFifoStatefulTransformPass
       }
     }
     createBd(builder, acqLock, acqMode, acqLockAction, relLock, relMode, buff,
-             offset, len, succ, dims, padDimensions);
+             offset, len, succ, dims, padDimensions, bdPacket);
   }
 
   /// Function that either calls createAIETileDMA(), createShimDMA() or
   /// createMemTileDMA() based on op tile row value.
   void createDMA(DeviceOp &device, OpBuilder &builder, ObjectFifoCreateOp op,
                  DMAChannelDir channelDir, int channelIndex, int lockMode,
-                 BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr pad_dims) {
+                 BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr pad_dims,
+                 std::optional<PacketInfoAttr> bdPacket) {
     if (op.getProducerTileOp().isShimTile()) {
       createShimDMA(device, builder, op, channelDir, channelIndex, lockMode,
-                    dims);
+                    dims, bdPacket);
     } else if (op.getProducerTileOp().isMemTile()) {
       BDPadLayoutArrayAttr padDims = nullptr;
       if (channelDir == DMAChannelDir::MM2S && pad_dims)
         padDims = pad_dims;
       createMemTileDMA(device, builder, op, channelDir, channelIndex, lockMode,
-                       dims, padDims);
+                       dims, padDims, bdPacket);
     } else {
       createAIETileDMA(device, builder, op, channelDir, channelIndex, lockMode,
-                       dims);
+                       dims, bdPacket);
     }
   }
 
@@ -614,7 +619,8 @@ struct AIEObjectFifoStatefulTransformPass
   void createAIETileDMA(DeviceOp &device, OpBuilder &builder,
                         ObjectFifoCreateOp op, DMAChannelDir channelDir,
                         int channelIndex, int lockMode,
-                        BDDimLayoutArrayAttr dims) {
+                        BDDimLayoutArrayAttr dims,
+                        std::optional<PacketInfoAttr> bdPacket) {
     size_t numBlocks = op.size();
     if (numBlocks == 0)
       return;
@@ -700,7 +706,7 @@ struct AIEObjectFifoStatefulTransformPass
         createBdBlock<BufferOp>(builder, target, lockMode, acqNum, relNum,
                                 buffersPerFifo[target][elemIndex], /*offset*/ 0,
                                 len, channelDir, elemIndex, succ, dims,
-                                nullptr);
+                                nullptr, bdPacket);
         curr = succ;
         totalBlocks++;
       }
@@ -713,7 +719,8 @@ struct AIEObjectFifoStatefulTransformPass
   void createShimDMA(DeviceOp &device, OpBuilder &builder,
                      ObjectFifoCreateOp op, DMAChannelDir channelDir,
                      int channelIndex, int lockMode,
-                     BDDimLayoutArrayAttr dims) {
+                     BDDimLayoutArrayAttr dims,
+                     std::optional<PacketInfoAttr> bdPacket) {
     size_t numBlocks = externalBuffersPerFifo[op].size();
     if (numBlocks == 0)
       return;
@@ -776,7 +783,7 @@ struct AIEObjectFifoStatefulTransformPass
       createBdBlock<ExternalBufferOp>(builder, op, lockMode, acqNum, relNum,
                                       externalBuffersPerFifo[op][elemIndex],
                                       /*offset*/ 0, len, channelDir, elemIndex,
-                                      succ, dims, nullptr);
+                                      succ, dims, nullptr, bdPacket);
       curr = succ;
       elemIndex++;
     }
@@ -788,7 +795,8 @@ struct AIEObjectFifoStatefulTransformPass
                         ObjectFifoCreateOp op, DMAChannelDir channelDir,
                         int channelIndex, int lockMode,
                         BDDimLayoutArrayAttr dims,
-                        BDPadLayoutArrayAttr padDimensions) {
+                        BDPadLayoutArrayAttr padDimensions,
+                        std::optional<PacketInfoAttr> bdPacket) {
     size_t numBlocks = op.size();
     if (numBlocks == 0)
       return;
@@ -949,7 +957,7 @@ struct AIEObjectFifoStatefulTransformPass
         createBdBlock<BufferOp>(builder, target, lockMode, acqNum, relNum,
                                 buffersPerFifo[target][elemIndex], offset,
                                 lenOut, channelDir, lockIndex, succ, dims,
-                                padDimensions, distribOrJoin);
+                                padDimensions, bdPacket, distribOrJoin);
         curr = succ;
         totalBlocks++;
       }
@@ -1406,12 +1414,16 @@ struct AIEObjectFifoStatefulTransformPass
   void createObjectFifoAllocationInfo(OpBuilder &builder, MLIRContext *ctx,
                                       FlatSymbolRefAttr obj_fifo, int colIndex,
                                       DMAChannelDir channelDir,
-                                      int channelIndex, bool plio) {
+                                      int channelIndex, bool plio,
+                                      std::optional<PacketInfoAttr> packet) {
+    PacketInfoAttr packetInfo = nullptr;
+    if (packet)
+      packetInfo = *packet;
     builder.create<ShimDMAAllocationOp>(builder.getUnknownLoc(), obj_fifo,
                                         DMAChannelDirAttr::get(ctx, channelDir),
                                         builder.getI64IntegerAttr(channelIndex),
                                         builder.getI64IntegerAttr(colIndex),
-                                        builder.getBoolAttr(plio));
+                                        builder.getBoolAttr(plio), packetInfo);
   }
 
   /// Function used to verify that an objectfifo is present in at most one
@@ -1432,6 +1444,18 @@ struct AIEObjectFifoStatefulTransformPass
         objectfifoset.insert(outOf);
       }
     }
+  }
+
+  /// Account for already used packet IDs and return next available ID.
+  int getStartPacketID(DeviceOp &device) {
+    int packetID = 0;
+    for (PacketFlowOp packetflow : device.getOps<PacketFlowOp>()) {
+      if (packetflow.getID() > packetID) {
+        // compute next available ID
+        packetID = packetflow.getID() + 1;
+      }
+    }
+    return packetID;
   }
 
   void runOnOperation() override {
@@ -1589,6 +1613,7 @@ struct AIEObjectFifoStatefulTransformPass
     //===------------------------------------------------------------------===//
     // Only the objectFifos we split above require DMA communication; the others
     // rely on shared memory and share the same buffers.
+    int packetID = getStartPacketID(device);
     for (auto &[producer, consumers] : splitFifos) {
       // create producer tile DMA
       int producerChanIndex = dmaAnalysis.getDMAChannelIndex(
@@ -1597,9 +1622,16 @@ struct AIEObjectFifoStatefulTransformPass
         producer.getProducerTileOp().emitOpError(
             "number of output DMA channel exceeded!");
       DMAChannel producerChan = {DMAChannelDir::MM2S, producerChanIndex};
+
+      std::optional<PacketInfoAttr> bdPacket = {};
+      if (clPacketSwObjectFifos) {
+        bdPacket = {AIE::PacketInfoAttr::get(
+            ctx, /*pkt_type*/ 0, /*pkt_id*/ packetID)};
+        packetID++;
+      }
       createDMA(device, builder, producer, producerChan.direction,
                 producerChan.channel, 0, producer.getDimensionsToStreamAttr(),
-                producer.getPadDimensionsAttr());
+                producer.getPadDimensionsAttr(), bdPacket);
       // generate objectFifo allocation info
       builder.setInsertionPoint(device.getBody()->getTerminator());
 
@@ -1607,7 +1639,22 @@ struct AIEObjectFifoStatefulTransformPass
         createObjectFifoAllocationInfo(
             builder, ctx, SymbolRefAttr::get(ctx, producer.getName()),
             producer.getProducerTileOp().colIndex(), producerChan.direction,
-            producerChan.channel, producer.getPlio());
+            producerChan.channel, producer.getPlio(), bdPacket);
+      
+      PacketFlowOp packetflow;
+      if (clPacketSwObjectFifos) {
+        // create packet flow
+        builder.setInsertionPointAfter(producer);
+        packetflow = builder.create<PacketFlowOp>(
+            builder.getUnknownLoc(),
+            builder.getIntegerAttr(builder.getI8Type(),
+            bdPacket->getPktId()), nullptr, nullptr);
+        {
+          OpBuilder::InsertionGuard g(builder);
+          builder.setInsertionPointToStart(&packetflow.getRegion().emplaceBlock());
+          builder.create<EndOp>(builder.getUnknownLoc());
+        }
+      }
 
       for (auto consumer : consumers) {
 
@@ -1621,7 +1668,7 @@ struct AIEObjectFifoStatefulTransformPass
         BDDimLayoutArrayAttr consumerDims =
             consumer.getDimensionsFromStreamPerConsumer()[0];
         createDMA(device, builder, consumer, consumerChan.direction,
-                  consumerChan.channel, 1, consumerDims, nullptr);
+                  consumerChan.channel, 1, consumerDims, nullptr, {});
         // generate objectFifo allocation info
         builder.setInsertionPoint(device.getBody()->getTerminator());
 
@@ -1638,18 +1685,33 @@ struct AIEObjectFifoStatefulTransformPass
           consumerWireType = WireBundle::DMA;
         }
 
+        if (clPacketSwObjectFifos) {
+          builder.setInsertionPointToStart(&packetflow.getPorts().front());
+          builder.create<PacketDestOp>(builder.getUnknownLoc(),
+                                      consumer.getProducerTile(),
+                                      WireBundle::DMA, consumerChan.channel);
+        }
+        builder.setInsertionPoint(device.getBody()->getTerminator());
         if (consumer.getProducerTileOp().isShimTile())
           createObjectFifoAllocationInfo(
               builder, ctx, SymbolRefAttr::get(ctx, producer.getName()),
               consumer.getProducerTileOp().colIndex(), consumerChan.direction,
-              consumerChan.channel, producer.getPlio());
-
-        // create flow
-        builder.setInsertionPointAfter(producer);
-        builder.create<FlowOp>(builder.getUnknownLoc(),
-                               producer.getProducerTile(), producerWireType,
-                               producerChan.channel, consumer.getProducerTile(),
-                               consumerWireType, consumerChan.channel);
+              consumerChan.channel, producer.getPlio(), {});
+        
+        if (!clPacketSwObjectFifos) {
+          // create flow
+          builder.setInsertionPointAfter(producer);
+          builder.create<FlowOp>(builder.getUnknownLoc(),
+                                 producer.getProducerTile(), producerWireType,
+                                 producerChan.channel, consumer.getProducerTile(),
+                                 consumerWireType, consumerChan.channel);
+        }
+      }
+      if (clPacketSwObjectFifos) {
+        builder.setInsertionPointToStart(&packetflow.getPorts().front());
+        builder.create<PacketSourceOp>(builder.getUnknownLoc(),
+                                      producer.getProducerTile(),
+                                      WireBundle::DMA, producerChan.channel);
       }
     }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoToPath.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoToPath.cpp
@@ -395,11 +395,14 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
   void createBd(OpBuilder &builder, LockOp acqLock, int acqMode,
                 LockAction acqLockAction, LockOp relLock, int relMode,
                 MyOp buff, int offset, int len, Block *succ,
-                BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr padDimensions) {
+                BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr padDimensions,
+                std::optional<PacketInfoAttr> bdPacket) {
     if (acqLock)
       builder.create<UseLockOp>(builder.getUnknownLoc(), acqLock, acqLockAction,
                                 acqMode);
-
+    if (bdPacket)
+      builder.create<DMABDPACKETOp>(builder.getUnknownLoc(), bdPacket->getPktType(),
+                                    bdPacket->getPktId());
     if (!dims.getValue().empty() && padDimensions) {
       builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len, dims,
                               padDimensions);
@@ -423,6 +426,7 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
                      DMAChannelDir channelDir, size_t lockIndex, Block *succ,
                      BDDimLayoutArrayAttr dims,
                      BDPadLayoutArrayAttr padDimensions,
+                     std::optional<PacketInfoAttr> bdPacket,
                      bool distribOrJoin = false) {
     LockOp acqLock;
     LockOp relLock;
@@ -456,26 +460,27 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
       }
     }
     createBd(builder, acqLock, acqMode, acqLockAction, relLock, relMode, buff,
-             offset, len, succ, dims, padDimensions);
+             offset, len, succ, dims, padDimensions, bdPacket);
   }
 
   /// Function that either calls createAIETileDMA(), createShimDMA() or
   /// createMemTileDMA() based on op tile row value.
   void createDMA(DeviceOp &device, OpBuilder &builder, ObjectFifoCreateOp op,
                  DMAChannelDir channelDir, int channelIndex, int lockMode,
-                 BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr pad_dims) {
+                 BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr pad_dims,
+                 std::optional<PacketInfoAttr> bdPacket) {
     if (op.getProducerTileOp().isShimTile()) {
       createShimDMA(device, builder, op, channelDir, channelIndex, lockMode,
-                    dims);
+                    dims, bdPacket);
     } else if (op.getProducerTileOp().isMemTile()) {
       BDPadLayoutArrayAttr padDims = nullptr;
       if (channelDir == DMAChannelDir::MM2S && pad_dims)
         padDims = pad_dims;
       createMemTileDMA(device, builder, op, channelDir, channelIndex, lockMode,
-                       dims, padDims);
+                       dims, padDims, bdPacket);
     } else {
       createAIETileDMA(device, builder, op, channelDir, channelIndex, lockMode,
-                       dims);
+                       dims, bdPacket);
     }
   }
 
@@ -484,7 +489,8 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
   void createAIETileDMA(DeviceOp &device, OpBuilder &builder,
                         ObjectFifoCreateOp op, DMAChannelDir channelDir,
                         int channelIndex, int lockMode,
-                        BDDimLayoutArrayAttr dims) {
+                        BDDimLayoutArrayAttr dims,
+                        std::optional<PacketInfoAttr> bdPacket) {
     size_t numBlocks = op.size();
     if (numBlocks == 0)
       return;
@@ -570,7 +576,7 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         createBdBlock<BufferOp>(builder, target, lockMode, acqNum, relNum,
                                 buffersPerFifo[target][elemIndex], /*offset*/ 0,
                                 len, channelDir, elemIndex, succ, dims,
-                                nullptr);
+                                nullptr, bdPacket);
         curr = succ;
         totalBlocks++;
       }
@@ -583,7 +589,8 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
   void createShimDMA(DeviceOp &device, OpBuilder &builder,
                      ObjectFifoCreateOp op, DMAChannelDir channelDir,
                      int channelIndex, int lockMode,
-                     BDDimLayoutArrayAttr dims) {
+                     BDDimLayoutArrayAttr dims,
+                     std::optional<PacketInfoAttr> bdPacket) {
     size_t numBlocks = externalBuffersPerFifo[op].size();
     if (numBlocks == 0)
       return;
@@ -646,7 +653,7 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
       createBdBlock<ExternalBufferOp>(builder, op, lockMode, acqNum, relNum,
                                       externalBuffersPerFifo[op][elemIndex],
                                       /*offset*/ 0, len, channelDir, elemIndex,
-                                      succ, dims, nullptr);
+                                      succ, dims, nullptr, bdPacket);
       curr = succ;
       elemIndex++;
     }
@@ -658,7 +665,8 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
                         ObjectFifoCreateOp op, DMAChannelDir channelDir,
                         int channelIndex, int lockMode,
                         BDDimLayoutArrayAttr dims,
-                        BDPadLayoutArrayAttr padDimensions) {
+                        BDPadLayoutArrayAttr padDimensions,
+                        std::optional<PacketInfoAttr> bdPacket) {
     size_t numBlocks = op.size();
     if (numBlocks == 0)
       return;
@@ -819,7 +827,7 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         createBdBlock<BufferOp>(builder, target, lockMode, acqNum, relNum,
                                 buffersPerFifo[target][elemIndex], offset,
                                 lenOut, channelDir, lockIndex, succ, dims,
-                                padDimensions, distribOrJoin);
+                                padDimensions, bdPacket, distribOrJoin);
         curr = succ;
         totalBlocks++;
       }
@@ -1089,12 +1097,15 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
   void createObjectFifoAllocationInfo(OpBuilder &builder, MLIRContext *ctx,
                                       FlatSymbolRefAttr obj_fifo, int colIndex,
                                       DMAChannelDir channelDir,
-                                      int channelIndex) {
+                                      int channelIndex, std::optional<PacketInfoAttr> packet) {
+    PacketInfoAttr packetInfo = nullptr;
+    if (packet)
+      packetInfo = *packet;
     builder.create<ShimDMAAllocationOp>(builder.getUnknownLoc(), obj_fifo,
                                         DMAChannelDirAttr::get(ctx, channelDir),
                                         builder.getI64IntegerAttr(channelIndex),
                                         builder.getI64IntegerAttr(colIndex),
-                                        builder.getBoolAttr(false));
+                                        builder.getBoolAttr(false), packetInfo);
   }
 
   /// Function used to verify that an objectfifo is present in at most one
@@ -1481,9 +1492,13 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         producer.getProducerTileOp().emitOpError(
             "number of output DMA channel exceeded!");
       DMAChannel producerChan = {DMAChannelDir::MM2S, producerChanIndex};
+
+      //TODO: fill in packet info if needed
+      //std::optional<PacketInfoAttr> bdPacket = {};
+
       createDMA(device, builder, producer, producerChan.direction,
                 producerChan.channel, 0, producer.getDimensionsToStreamAttr(),
-                producer.getPadDimensionsAttr());
+                producer.getPadDimensionsAttr(), /*TODO_PKT_CHANGE*/{});
       // generate objectFifo allocation info
       builder.setInsertionPoint(device.getBody()->getTerminator());
 
@@ -1491,7 +1506,10 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         createObjectFifoAllocationInfo(
             builder, ctx, SymbolRefAttr::get(ctx, producer.getName()),
             producer.getProducerTileOp().colIndex(), producerChan.direction,
-            producerChan.channel);
+            producerChan.channel, /*TODO_PKT_CHANGE*/{});
+      
+      //TODO: if it's packet switched, create packetflowop here
+      
       SmallVector<int32_t> consChannels;
       for (auto consumer : consumers) {
         // create consumer tile DMA
@@ -1505,16 +1523,21 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         BDDimLayoutArrayAttr consumerDims =
             consumer.getDimensionsFromStreamPerConsumer()[0];
         createDMA(device, builder, consumer, consumerChan.direction,
-                  consumerChan.channel, 1, consumerDims, nullptr);
+                  consumerChan.channel, 1, consumerDims, nullptr, {});
         // generate objectFifo allocation info
         builder.setInsertionPoint(device.getBody()->getTerminator());
+        
+        //TODO: if packet switched, create a packetdestop at consumer
 
         if (consumer.getProducerTileOp().isShimTile())
           createObjectFifoAllocationInfo(
               builder, ctx, SymbolRefAttr::get(ctx, producer.getName()),
               consumer.getProducerTileOp().colIndex(), consumerChan.direction,
-              consumerChan.channel);
+              consumerChan.channel, {});
       }
+
+      //TODO: if packet switched, create packetsourceop here
+      // create path op TBD
 
       auto dstChannelsAttr = DenseI32ArrayAttr::get(builder.getContext(),
           llvm::ArrayRef(consChannels));

--- a/lib/Dialect/AIE/Transforms/AIEReconstructRouting.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEReconstructRouting.cpp
@@ -11,21 +11,32 @@ using namespace xilinx;
 using namespace xilinx::AIE;
 using json = nlohmann::ordered_json;
 
+typedef struct MaskValue {
+  int mask;
+  int value;
+} MaskValue;
+
 typedef struct PortConnection {
   Operation *op;
   Port port;
 } PortConnection;
 
+typedef struct PortMaskValue {
+  Port port;
+  MaskValue mv;
+} PortMaskValue;
+
 typedef struct WorkItem {
   Operation *op;
   Port port;
   std::vector<TileOp> currentPath;
+  MaskValue mv;
 } WorkItem;
 
 typedef struct Path {
   TileOp srcTile;
   std::vector<TileOp> dstTiles;
-  std::vector<std::vector<TileOp>> paths;
+  std::vector<std::pair<std::vector<TileOp>, MaskValue>> paths;
 
   Path(TileOp src) : srcTile(src) {}
 } Path;
@@ -62,18 +73,48 @@ private:
     return std::nullopt;
   }
   
-  std::vector<Port> getConnectionsThroughSwitchbox(Region &r, Port sourcePort) {
+  std::vector<PortMaskValue> getConnectionsThroughSwitchbox(Region &r, Port sourcePort) {
     LLVM_DEBUG(llvm::dbgs() << "Switchbox:\n");
     Block &b = r.front();
-    std::vector<Port> portSet;
+    std::vector<PortMaskValue> portSet;
     for (auto connectOp : b.getOps<ConnectOp>()) {
       if (connectOp.sourcePort() == sourcePort) {
-        portSet.push_back(connectOp.destPort());
+        MaskValue maskValue = {0, 0};
+        portSet.push_back({connectOp.destPort(), maskValue});
         LLVM_DEBUG(llvm::dbgs() << "To:" << stringifyWireBundle(connectOp.destPort().bundle)
                 << " " << connectOp.destPort().channel << "\n");
       }
     }
+    for (auto connectOp : b.getOps<PacketRulesOp>()) {
+      if (connectOp.sourcePort() == sourcePort) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Packet From: "
+                   << stringifyWireBundle(connectOp.sourcePort().bundle) << " "
+                   << sourcePort.channel << "\n");
+        for (auto masterSetOp : b.getOps<MasterSetOp>()) 
+          for (Value amsel : masterSetOp.getAmsels())
+            for (auto ruleOp : connectOp.getRules().front().getOps<PacketRuleOp>()) {
+              if (ruleOp.getAmsel() == amsel) {
+                LLVM_DEBUG(llvm::dbgs()
+                           << "To:"
+                           << stringifyWireBundle(masterSetOp.destPort().bundle)
+                           << " " << masterSetOp.destPort().channel << "\n");
+                MaskValue maskValue = {ruleOp.maskInt(), ruleOp.valueInt()};
+                portSet.push_back({masterSetOp.destPort(), maskValue});
+              }
+            }
+      }
+    }
     return portSet;
+  }
+
+  std::optional<MaskValue> matchMask(const MaskValue &curr, const MaskValue &next) const {
+    int maskConflicts = next.mask & curr.mask;
+    if ((maskConflicts & next.value) != (maskConflicts & curr.value))
+      return std::nullopt;
+    MaskValue newMaskValue = {curr.mask | next.mask,
+                              curr.value | (next.mask & next.value)};
+    return newMaskValue;
   }
 
 public: 
@@ -86,7 +127,7 @@ public:
       return pathInfo; // no connections, return
 
     std::vector<WorkItem> worklist;
-    worklist.push_back({firstConn->op, firstConn->port, {tileOp}});
+    worklist.push_back({firstConn->op, firstConn->port, {tileOp}, {0, 0}});
 
     while(!worklist.empty()) {
       WorkItem wItem = worklist.back();
@@ -113,30 +154,36 @@ public:
         auto dstTileOp = dyn_cast<TileOp>(other);
         if (dstTileOp) {
           pathInfo.dstTiles.push_back(dstTileOp);
-          pathInfo.paths.push_back(currentPath);
+          pathInfo.paths.push_back({currentPath, wItem.mv});
         }
       } else if (auto switchOp = dyn_cast_or_null<SwitchboxOp>(other)) {
-        auto nextPorts = getConnectionsThroughSwitchbox(
+        auto nextPortMVs = getConnectionsThroughSwitchbox(
                             switchOp.getConnections(), otherPort);
         // need to add next ports to check
-        for (auto &port : nextPorts) {
-          auto nextConnection = getConnectionThroughWire(switchOp, port);
+        for (auto &portMV : nextPortMVs) {
+          auto mergedMV = matchMask(wItem.mv, portMV.mv);
+          if (!mergedMV)
+            continue;
+          auto nextConnection = getConnectionThroughWire(switchOp, portMV.port);
           if (nextConnection) {
             // clone path for each branch
             auto newPath = currentPath;
-            worklist.push_back({nextConnection->op, nextConnection->port, newPath});
+            worklist.push_back({nextConnection->op, nextConnection->port, newPath, *mergedMV});
           }
         }
       } else if (auto switchOp = dyn_cast_or_null<ShimMuxOp>(other)) {
-        auto nextPorts = getConnectionsThroughSwitchbox(
+        auto nextPortMVs = getConnectionsThroughSwitchbox(
                             switchOp.getConnections(), otherPort);
         // need to add next ports to check
-        for (auto &port : nextPorts) {
-          auto nextConnection = getConnectionThroughWire(switchOp, port);
+        for (auto &portMV : nextPortMVs) {
+          auto mergedMV = matchMask(wItem.mv, portMV.mv);
+          if (!mergedMV)
+            continue;
+          auto nextConnection = getConnectionThroughWire(switchOp, portMV.port);
           if (nextConnection) {
             // clone path for each branch
             auto newPath = currentPath;
-            worklist.push_back({nextConnection->op, nextConnection->port, newPath});
+            worklist.push_back({nextConnection->op, nextConnection->port, newPath, *mergedMV});
           }
         }
       }
@@ -156,6 +203,7 @@ struct AIEReconstructRoutingPass :
     output["buffers"] = json::array();
     output["cct_routes"] = json::array();
     output["nbr_routes"] = json::array();
+    output["pkt_routes"] = json::array();
     
     // Map of (col, row) to list of allocated buffers
     std::map<std::pair<int, int>, std::vector<int64_t>> bufferMap;
@@ -189,10 +237,14 @@ struct AIEReconstructRoutingPass :
       // Perform analysis on each tile
       for (WireBundle bundle : bundles) {
         for (size_t i = 0; i < tile.getNumSourceConnections(bundle); i++) {
-          Path pInfo = analysis.getPathInfo(tile, {bundle, i});
+          Path pInfo = analysis.getPathInfo(tile, {bundle, (int)i});
           std::vector<std::vector<std::pair<int, int>>> routes;
+          bool isPkt = true;
           if (!pInfo.paths.empty()) {
-            for (auto path : pInfo.paths) {
+            for (auto &[path, mv] : pInfo.paths) {
+              if (mv.mask == 0 && mv.value == 0) {
+                isPkt = false;
+              }
               std::vector<std::pair<int, int>> route;
               for (auto t : path) {
                 route.push_back({t.getCol(), t.getRow()});
@@ -218,7 +270,11 @@ struct AIEReconstructRoutingPass :
               intermediatesArray.push_back(routeJson);
             }
             routeGroup["intermediates"] = intermediatesArray;
-            output["cct_routes"].push_back(routeGroup);
+            if (isPkt) {
+              output["pkt_routes"].push_back(routeGroup);
+            } else {
+              output["cct_routes"].push_back(routeGroup);
+            }
           }
         }
       }

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -491,6 +491,10 @@ LogicalResult AIEX::NpuWriteBdOp::verify() {
       (getD0Size() >= 1) && (getD1Size() == 1) && (getIterationSize() == 0);
   if (getBdId() > numBds)
     return emitOpError("BD ID exceeds the maximum ID.");
+  if (getPacketId() > 31)
+    return emitOpError("Packet ID exceeds the 5-bit [0:31] range.");
+  if (getPacketType() > 7)
+    return emitOpError("Packet Type exceeds the 3-bit [0:7] range.");
   if (!isLinearTransfer && getD0Size() > 0x3FF)
     return emitOpError("D0 Size exceeds the [0:1023] range.");
   if (getD0Stride() > 0xFFFFF)

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -218,7 +218,8 @@ struct AIEDMATasksToNPUPass : AIEDMATasksToNPUBase<AIEDMATasksToNPUPass> {
 
   LogicalResult rewriteSingleBD(OpBuilder &builder, Block &block,
                                 AIE::TileOp &tile,
-                                AIE::DMAChannelDir channelDir) {
+                                AIE::DMAChannelDir channelDir,
+                                std::optional<xilinx::AIE::PacketInfoAttr> packet) {
     AIE::DMABDOp bd_op = getBdForBlock(block);
     const auto &target_model = AIE::getTargetModel(bd_op);
     MemRefType buffer_type = bd_op.getBuffer().getType();
@@ -255,6 +256,9 @@ struct AIEDMATasksToNPUPass : AIEDMATasksToNPUBase<AIEDMATasksToNPUPass> {
     std::fill(padBefore.begin(), padBefore.end(), 0);
     std::fill(padAfter.begin(), padAfter.end(), 0);
 
+    auto enable_packet = 0;
+    auto packet_id = 0;
+    auto packet_type = 0;
     auto d0size = 0;
     auto d0stride = 0;
     auto d1size = 0;
@@ -390,9 +394,21 @@ struct AIEDMATasksToNPUPass : AIEDMATasksToNPUBase<AIEDMATasksToNPUPass> {
       use_next_bd = 1;
     }
 
+    // enable_packet
+    // auto info = bd_op.getPacket() ? bd_op.getPacket() : packet;
+    auto info = bd_op.getPacket().value_or(packet.value_or(nullptr));
+    if (info) {
+      enable_packet = 1;
+      packet_type = info.getPktType();
+      packet_id = info.getPktId();
+    }
+
     builder.create<NpuWriteBdOp>(
-        bd_op.getLoc(), tile.getCol(), bd_id, len_addr_granularity, offset, 0,
-        0, 0, 0,
+        bd_op.getLoc(), tile.getCol(), bd_id, len_addr_granularity, offset, 
+        /*enable_packet=*/enable_packet,
+        /*out_of_order_id=*/0,
+        /*packet_id=*/packet_id,
+        /*packet_type=*/packet_type,
         /* TODO: Strides/Wraps */
         /*d0_size=*/d0size, /*d0_stride=*/d0stride,
         /*d1_size=*/d1size, /*d1_stride=*/d1stride,
@@ -486,6 +502,7 @@ struct AIEDMATasksToNPUPass : AIEDMATasksToNPUBase<AIEDMATasksToNPUPass> {
     }
 
     auto channelDir = op.getDirection();
+    auto packet = op.getPacket();
 
     // Lower all BDs
     for (auto it = body.begin(); it != body.end(); ++it) {
@@ -493,7 +510,7 @@ struct AIEDMATasksToNPUPass : AIEDMATasksToNPUBase<AIEDMATasksToNPUPass> {
       if (shouldSkipBlock(block)) {
         continue;
       }
-      if (failed(rewriteSingleBD(builder, block, tile, channelDir))) {
+      if (failed(rewriteSingleBD(builder, block, tile, channelDir, packet))) {
         return failure();
       }
     }

--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -47,7 +47,8 @@ struct DMAConfigureTaskForOpPattern
     DMAConfigureTaskOp new_op = rewriter.create<DMAConfigureTaskOp>(
         op.getLoc(), rewriter.getIndexType(), tile.getResult(),
         alloc_op.getChannelDir(), (int32_t)alloc_op.getChannelIndex(),
-        op.getIssueToken(), op.getRepeatCount());
+        op.getIssueToken(), op.getRepeatCount(),
+        alloc_op.getPacket().value_or(nullptr));
     rewriter.replaceAllUsesWith(op.getResult(), new_op.getResult());
     rewriter.inlineRegionBefore(op.getBody(), new_op.getBody(),
                                 new_op.getBody().begin());

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -324,6 +324,13 @@ def parse_args(args=None):
         help="Kernel id in xclbin file",
     )
     parser.add_argument(
+        "--packet-sw-objFifos",
+        dest="packet_sw_objFifos",
+        default=False,
+        action="store_true",
+        help="Use packet switched flows when lowering object fifos",
+    )
+    parser.add_argument(
         "--use-pnr-routing",
         dest="pnr_routing",
         default=False,

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -34,7 +34,7 @@ from aie.dialects import aie as aiedialect
 from aie.ir import Context, Location, Module
 from aie.passmanager import PassManager
 
-INPUT_WITH_ADDRESSES_PIPELINE = lambda scheme, dynamic_objFifos, ctrl_pkt_overlay: (
+INPUT_WITH_ADDRESSES_PIPELINE = lambda scheme, dynamic_objFifos, packet_sw_objFifos, ctrl_pkt_overlay: (
     Pipeline()
     .lower_affine()
     .add_pass("aie-canonicalize-device")
@@ -44,7 +44,8 @@ INPUT_WITH_ADDRESSES_PIPELINE = lambda scheme, dynamic_objFifos, ctrl_pkt_overla
         .add_pass("aie-assign-lock-ids")
         .add_pass("aie-register-objectFifos")
         .add_pass(
-            "aie-objectFifo-stateful-transform", dynamic_objFifos=dynamic_objFifos
+            "aie-objectFifo-stateful-transform", dynamic_objFifos=dynamic_objFifos,
+            packet_sw_objFifos=packet_sw_objFifos
         )
         .add_pass("aie-assign-bd-ids")
         .add_pass("aie-lower-cascade-flows")
@@ -1127,7 +1128,7 @@ class FlowRunner:
                 ).materialize(module=True)
             else:
                 pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE(
-                    opts.alloc_scheme, opts.dynamic_objFifos, opts.ctrl_pkt_overlay
+                    opts.alloc_scheme, opts.dynamic_objFifos, opts.packet_sw_objFifos, opts.ctrl_pkt_overlay
                 ).materialize(module=True)
 
             file_with_addresses = self.prepend_tmp("input_with_addresses.mlir")


### PR DESCRIPTION
### Summary
Since fork, AMD has added lowering support at ObjectFifo level for packet routing. This PR merges in those changes.

### Changes
- Standard MLIR-AIE pipeline can choose to lower ObjectFifos as either `aie.flow` (circuit-switched) or `aie.packet_flow` (packet-switched).
- This option is added to `aiecc.py` as `--packet-sw-objFifos` to toggle between the two routing choices.
-  `--aie-reconstruct-routing` pass that parses out routing paths now does so for packet routing too.
### TODOs for ueqri/npu-flow:
- Update pnr vs aiecc routing verification to compare pkt routes.
- Expose `--packet-sw-objFifos` to `build_benchmarks.py`
