### PR TITLE
Replaced via_shared_mem with new allocate definition

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -434,8 +434,7 @@ def AIE_ConnectOp: AIE_Op<"connect", [ParentOneOf<["SwitchboxOp", "ShimMuxOp"]> 
 def AIE_NeighbourPathOp : AIE_Op<"neighbour_path", []> {
   let arguments = (
     ins Index:$source,
-        Variadic<Index>:$dests,
-        OptionalAttr<ArrayAttr>:$via_shared_mems
+        Variadic<Index>:$dests
   );
   let summary = "An explicit path op to indicate using local memory access between cores";
   let description = [{
@@ -1791,9 +1790,6 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
         // disable_synchronization==true will skip lock generation for
         // objectfifo synchronous accesses
         DefaultValuedAttr<BoolAttr, "false">:$disable_synchronization,
-        // via_shared_mem==-1 means use producer tile's memory module
-        // via_shared_mem==1 means use consumer tile's memory module
-        OptionalAttr<ArrayAttr>:$via_shared_mem,
         // repeat_count==1 means "do it once"
         OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<1>]>>:$repeat_count,
         InitValuesArrayAttr:$initValues,
@@ -1832,25 +1828,6 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
       return getOperation()->getAttrOfType<mlir::StringAttr>(
           mlir::SymbolTable::getSymbolAttrName());
     }
-
-    int sharedMemValue(int index = 0) {
-      if (getViaSharedMem().has_value())
-        return llvm::dyn_cast<mlir::IntegerAttr>(getViaSharedMem().value()[index])
-            .getInt();
-      return -2;
-    }
-
-    int numSharedMemConsumers(int shareDirection) {
-      int count = 0;
-      if (!getViaSharedMem()) return count;
-      auto arrayAttr = getViaSharedMem().value();
-      for (auto attr : arrayAttr) {
-        if (llvm::dyn_cast<mlir::IntegerAttr>(attr).getInt() == shareDirection)
-          count++;
-      }
-      return count;
-    }
-
   }];
 
   let builders = [
@@ -1870,6 +1847,40 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
                             odsBuilder.getAttr<BDDimLayoutArrayArrayAttr>(dimensionsFromStreamPerConsumer));
     }]>
   ];
+}
+
+def AIE_ObjectFifoAllocateOp: AIE_Op<"objectfifo.allocate", [HasParent<"DeviceOp">]> {
+  let summary = "Sets a tile's memory module as the target for an objectfifo's memory allocation";
+  let description = [{
+    Specify a tile's memory module to be used as the allocation target for this objectfifo.
+    Only works if all the objectfifo's tiles, producer and consumers, have shared memory access to
+    the specified tile's memory module.
+
+    In the following example the objects of @of4 will be allocated on %tile14:
+    ```
+      aie.objectfifo @of4 (%tile13, {%tile14}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+      aie.objectfifo.allocate @of4 (%tile14)
+    ```
+  }];
+
+  let arguments = (
+    ins FlatSymbolRefAttr:$objFifo_name,
+        Variadic<Index>:$delegateTiles
+  );
+
+  let hasCustomAssemblyFormat = 1;
+
+  let assemblyFormat = [{
+    $objFifo_name `(` $delegateTiles `)` attr-dict
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ObjectFifoCreateOp getObjectFifo();
+    std::vector<TileOp> getDelegateTileOps();
+    int getNumSrcDelegates();
+  }];
 }
 
 def AIE_ObjectFifoLinkOp: AIE_Op<"objectfifo.link", [HasParent<"DeviceOp">]> {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -422,11 +422,6 @@ LogicalResult ObjectFifoCreateOp::verify() {
         "on shim tile producers");
   }
 
-  if (getViaSharedMem().has_value()) {
-    if (getVia_DMA())
-      return emitError("`via_shared_mem` and `via_DMA` cannot occur together");
-  }
-
   if (getRepeatCount().has_value()) {
     if (getProducerTileOp().isShimTile())
       return emitError("`repeat_count` unavailable for shim tiles");
@@ -582,6 +577,57 @@ static ParseResult parseObjectFifoInitValues(OpAsmParser &parser,
   }
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ObjectFifoAllocateOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ObjectFifoAllocateOp::verify() {
+  ObjectFifoCreateOp objFifo = getObjectFifo();
+  if (!objFifo)
+    return emitError("cannot retrieve associated object FIFO");
+  if (objFifo.getVia_DMA())
+    return emitError("cannot allocate a shared memory module to objectfifo "
+                     "with set `via_DMA` attribute");
+  if (objFifo.getRepeatCount().has_value())
+    return emitError("cannot allocate a shared memory module to objectfifo "
+                     "with set `repeat_count` attribute");
+  if (!objFifo.getDimensionsToStream().empty())
+    return emitError("cannot allocate a shared memory module to objectfifo "
+                     "with set dimensions attribute");
+  return success();
+}
+
+std::vector<TileOp> ObjectFifoAllocateOp::getDelegateTileOps() {
+  std::vector<TileOp> tiles;
+  for (auto tile : getDelegateTiles()) {
+    tiles.push_back(cast<TileOp>(tile.getDefiningOp()));
+  }
+  return tiles;
+} 
+
+ObjectFifoCreateOp ObjectFifoAllocateOp::getObjectFifo() {
+  Operation *parent = getOperation();
+  while ((parent = parent->getParentOp())) {
+    if (parent->hasTrait<OpTrait::SymbolTable>()) {
+      if (auto *st = SymbolTable::lookupSymbolIn(parent, getObjFifoName());
+          isa_and_nonnull<ObjectFifoCreateOp>(st))
+        return dyn_cast<ObjectFifoCreateOp>(st);
+    }
+  }
+  return {};
+}
+
+int ObjectFifoAllocateOp::getNumSrcDelegates() {
+    ObjectFifoCreateOp of = getObjectFifo();
+    auto prodTileOp = of.getProducerTileOp();
+    int count = 0;
+    for (auto t : getDelegateTileOps()) {
+        if (t == prodTileOp)
+            count++;
+    }
+    return count;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -177,6 +177,26 @@ struct AIEObjectFifoStatefulTransformPass
     return leftShared || rightShared;
   }
 
+  /// Function to retrieve ObjectFifoAllocateOp of ObjectFifoCreateOp,
+  /// if it exists.
+  std::optional<ObjectFifoAllocateOp>
+  getOptionalAllocateOp(ObjectFifoCreateOp op) {
+    ObjectFifoAllocateOp allocOp;
+    auto device = op->getParentOfType<DeviceOp>();
+    bool foundAlloc = false;
+    for (ObjectFifoAllocateOp alloc : device.getOps<ObjectFifoAllocateOp>()) {
+      if (alloc.getObjectFifo() == op) {
+        if (foundAlloc)
+          op.emitOpError("has more than one allocate operation");
+        allocOp = alloc;
+        foundAlloc = true;
+      }
+    }
+    if (foundAlloc)
+      return {allocOp};
+    return {};
+  }
+
   // Return true if the objectFifo created by createOp requires a DMA to be set
   // up. This is the case if the tiles are not adjacent (no shared memory), if
   // the objectFifo broadcasts to multiple tiles, if one of the consumers or
@@ -235,7 +255,6 @@ struct AIEObjectFifoStatefulTransformPass
     if (hasSharedMemory) {
       if (auto linkOp = getOptionalLinkOp(createOp)) {
         isUsedInLinkOp = true;
-        int share_dir = 0;
         if (!linkOp->isDistribute() && !linkOp->isJoin()) {
           auto fifoInType = llvm::cast<AIEObjectFifoType>(
               linkOp->getInputObjectFifos()[0].getElemType());
@@ -250,9 +269,18 @@ struct AIEObjectFifoStatefulTransformPass
             // memory without DMAs
             splitBecauseLink.push_back(createOp);
           }
-          if (createOp.getViaSharedMem().has_value()) {
-            checkAndApplyViaSharedMemAttribute(createOp, share_dir);
-            if (share_direction == share_dir)
+          std::optional<ObjectFifoAllocateOp> opAlloc =
+              getOptionalAllocateOp(createOp);
+          if (opAlloc.has_value()) {
+            TileOp delegate = opAlloc->getDelegateTileOps()[0];
+            int prodShareDir;
+            int consShareDir;
+            auto consumerTileOp = dyn_cast<TileOp>(
+                createOp.getConsumerTiles()[0].getDefiningOp());
+            isSharedMemory(delegate, createOp.getProducerTileOp(),
+                           &prodShareDir);
+            isSharedMemory(delegate, consumerTileOp, &consShareDir);
+            if (prodShareDir == -1 && consShareDir == -1)
               isUsedInLinkOp = false;
             else
               splitBecauseLink.push_back(createOp);
@@ -265,43 +293,6 @@ struct AIEObjectFifoStatefulTransformPass
 
     return !hasSharedMemory || atLeastOneConsumerWantsTransform ||
            isUsedInLinkOp;
-  }
-
-  // Checks if via_shared_mem attribute of the objectfifo is set and if so
-  // tries to apply it. If the desired shared memory module is available to
-  // both producer and consumer then it will be used, otherwise an error is
-  // emitted.
-  void checkAndApplyViaSharedMemAttribute(ObjectFifoCreateOp createOp,
-                                          int &share_direction) {
-    if (createOp.getViaSharedMem().has_value()) {
-      int desiredSharedTile = createOp.sharedMemValue();
-      int desiredSharedModule = 1;
-      if (desiredSharedTile == 0)
-        desiredSharedModule = -1;
-      if (share_direction != desiredSharedModule) {
-        bool desiredSharedModuleIsShared = false;
-        int newShareDirection = 0;
-        for (auto consumerTile : createOp.getConsumerTiles()) {
-          if (auto consumerTileOp =
-                  dyn_cast<TileOp>(consumerTile.getDefiningOp()))
-            if (share_direction == -1)
-              ///   * -1 if the shared memory module is that of the first input
-              ///   tile,
-              ///   * 1 if it is that of the second input tile
-              desiredSharedModuleIsShared =
-                  isSharedMemory(consumerTileOp, createOp.getProducerTileOp(),
-                                 &newShareDirection);
-        }
-        if (desiredSharedModuleIsShared) {
-          if (share_direction == newShareDirection)
-            share_direction = (share_direction == -1) ? 1 : -1;
-          else
-            createOp->emitOpError(
-                "no access to shared memory module specified by "
-                "`via_shared_mem`");
-        }
-      }
-    }
   }
 
   /// Function to retrieve ObjectFifoLinkOp of ObjectFifoCreateOp,
@@ -458,12 +449,25 @@ struct AIEObjectFifoStatefulTransformPass
     }
 
     TileOp creation_tile;
+    auto consumerTileOp =
+        dyn_cast<TileOp>(op.getConsumerTiles()[0].getDefiningOp());
     if (share_direction == 0 || share_direction == -1)
       creation_tile = op.getProducerTileOp();
-    else {
-      auto consumerTileOp =
-          dyn_cast<TileOp>(op.getConsumerTiles()[0].getDefiningOp());
+    else 
       creation_tile = consumerTileOp;
+
+    std::optional<ObjectFifoAllocateOp> opAlloc = getOptionalAllocateOp(op);
+    if (opAlloc.has_value()) {
+      TileOp delegate = opAlloc->getDelegateTileOps()[0];
+      int prodShareDir;
+      int consShareDir;
+      isSharedMemory(delegate, op.getProducerTileOp(), &prodShareDir);
+      isSharedMemory(delegate, consumerTileOp, &consShareDir);
+      if (prodShareDir == -1 && consShareDir == -1)
+        creation_tile = delegate;
+      else
+        opAlloc->emitOpError("objectfifo has no shared memory access to "
+                             "delegate tile's memory module");
     }
 
     // Reset opbuilder location to after the last tile declaration
@@ -1583,15 +1587,9 @@ struct AIEObjectFifoStatefulTransformPass
 
       // if split, the necessary size for producer fifo might change
       if (shared) {
-        checkAndApplyViaSharedMemAttribute(createOp, share_direction);
         createObjectFifoElements(builder, lockAnalysis, createOp,
                                  share_direction);
       } else {
-        if (createOp.getViaSharedMem().has_value())
-          createOp->emitOpError(
-              "no access to shared memory module specified by "
-              "`via_shared_mem`");
-
         if (isa<ArrayAttr>(createOp.getElemNumber()))
           createOp.setElemNumberAttr(
               builder.getI32IntegerAttr(createOp.size()));
@@ -1966,7 +1964,8 @@ struct AIEObjectFifoStatefulTransformPass
     device.walk([&](Operation *op) {
       if (isa<ObjectFifoCreateOp, ObjectFifoLinkOp,
               ObjectFifoRegisterExternalBuffersOp, ObjectFifoAcquireOp,
-              ObjectFifoSubviewAccessOp, ObjectFifoReleaseOp>(op))
+              ObjectFifoSubviewAccessOp, ObjectFifoReleaseOp,
+              ObjectFifoAllocateOp>(op))
         opsToErase.insert(op);
     });
     SmallVector<Operation *> sorted{opsToErase.begin(), opsToErase.end()};

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoToPath.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoToPath.cpp
@@ -192,13 +192,16 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
                    std::string name, Value prodTile, Value consTile,
                    Attribute depth, BDDimLayoutArrayAttr dimensionsToStream,
                    BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer,
-                   ArrayAttr viaSharedMem = nullptr) {
+                   bool allocate = false) {
     auto ofName = builder.getStringAttr(name);
     auto fifo = builder.create<ObjectFifoCreateOp>(
         builder.getUnknownLoc(), ofName, prodTile, consTile, depth, datatype,
         dimensionsToStream, dimensionsFromStreamPerConsumer);
-    if (viaSharedMem)
-      fifo.setViaSharedMemAttr(viaSharedMem);
+    if (allocate) {
+      auto symRef = FlatSymbolRefAttr::get(builder.getContext(), fifo.getSymName());
+      builder.create<ObjectFifoAllocateOp>(builder.getUnknownLoc(), symRef, 
+                                           ArrayRef<Value>{consTile});
+    }
     return fifo;
   }
 
@@ -221,7 +224,8 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         numElem = externalBuffersPerFifo[op].size();
     }
     int numConsumers = 1;
-    if (op.getViaSharedMem().has_value())
+    std::optional<ObjectFifoAllocateOp> opAlloc = getOptionalAllocateOp(op);
+    if (opAlloc.has_value() && opAlloc->getNumSrcDelegates() > 1)
       numConsumers = op.getConsumerTiles().size();
     // create corresponding aie2 locks
     for (int c = 0; c < numConsumers; c++) {
@@ -335,7 +339,11 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
           dyn_cast<TileOp>(op.getConsumerTiles()[0].getDefiningOp());
       creation_tile = consumerTileOp;
     }
-
+    std::optional<ObjectFifoAllocateOp> opAlloc = getOptionalAllocateOp(op);
+    if (opAlloc.has_value() && opAlloc->getDelegateTileOps().size() == 1) {
+      TileOp delegate = opAlloc->getDelegateTileOps()[0];
+      creation_tile = delegate;
+    }
     // Reset opbuilder location to after the last tile declaration
     Operation *t = nullptr;
     auto dev = op->getParentOfType<DeviceOp>();
@@ -1222,8 +1230,14 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
   // core must process its own lock index within the FIFO. If FIFO is single cast
   // returns index 0.
   SmallVector<int> getLockIndices(ObjectFifoCreateOp op, TileOp coreTile, TileOp fifoProdTile) {
+    std::optional<ObjectFifoAllocateOp> opAlloc = getOptionalAllocateOp(op);
+    // one-to-one or one-to-many DMAs should not have allocate (for now)
+    if (!opAlloc.has_value())
+      return {0};
+
+    auto delegates = opAlloc->getDelegateTileOps();
     SmallVector<int> lockIndices;
-    if (op.numSharedMemConsumers(-1) > 1) {
+    if (delegates.size() > 1) {
       if (coreTile == fifoProdTile) {
         // Producer core with mem-on-src for multiple consumers
         // process all locks
@@ -1243,10 +1257,30 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
       }
     }
     else {
-      // one-to-one DMA or mem-on-sink FIFO
+      // one-to-one/one-to-many DMA or mem-on-sink FIFO
       lockIndices.push_back(0);
     }
     return lockIndices;  
+  }
+
+  /// Function to retrieve ObjectFifoAllocateOp of ObjectFifoCreateOp,
+  /// if it exists.
+  std::optional<ObjectFifoAllocateOp>
+  getOptionalAllocateOp(ObjectFifoCreateOp op) {
+    ObjectFifoAllocateOp allocOp;
+    auto device = op->getParentOfType<DeviceOp>();
+    bool foundAlloc = false;
+    for (ObjectFifoAllocateOp alloc : device.getOps<ObjectFifoAllocateOp>()) {
+      if (alloc.getObjectFifo() == op) {
+        if (foundAlloc)
+          op.emitOpError("has more than one allocate operation");
+        allocOp = alloc;
+        foundAlloc = true;
+      }
+    }
+    if (foundAlloc)
+      return {allocOp};
+    return {};
   }
 
   void runOnOperation() override {
@@ -1277,18 +1311,21 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
       std::vector<ObjectFifoCreateOp> splitConsumerFifos;
       int consumerIndex = 0;
       auto producerTile = createOp.getProducerTile();
+      auto producerTileOp = createOp.getProducerTileOp();
       ArrayRef<BDDimLayoutArrayAttr> consumerDims =
           createOp.getDimensionsFromStreamPerConsumer();
+      std::optional<ObjectFifoAllocateOp> opAlloc =
+          getOptionalAllocateOp(createOp);
       // Only FIFOs using DMA or multi-cast via shared memory 
       // are split into two ends; skip in shared memory one-to-one case
-      if (createOp.getViaSharedMem().has_value() && 
+      if (!createOp.getVia_DMA() && 
           createOp.getConsumerTiles().size() <= 1)
         continue;
 
       SmallVector<Value> memOnSrcConsumers;
       for (auto consumerTile : createOp.getConsumerTiles()) {
-        if (createOp.getViaSharedMem().has_value() &&
-            createOp.sharedMemValue(consumerIndex) == -1) {
+        if (!createOp.getVia_DMA() && opAlloc.has_value() && 
+            opAlloc->getDelegateTileOps()[consumerIndex] == producerTileOp) {
           memOnSrcConsumers.push_back(consumerTile);
           consumerIndex++;
           continue;
@@ -1300,7 +1337,6 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
 
         // Fifo creation parameters
         auto datatype = llvm::cast<AIEObjectFifoType>(createOp.getElemType());
-        ArrayAttr viaSharedMem = nullptr;
         std::string conSuffix;
         int consumerDepth = createOp.size();
         std::string consumerFifoName;
@@ -1313,16 +1349,10 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
             consumerDepth = findObjectFifoSize(device, consumerTileOp, createOp);
           }
           conSuffix = "_cons";
-        } else if (createOp.getViaSharedMem().has_value()) {
-          // Share direction has to be on consumer -> 1
+        } else {
           conSuffix = "_nbr_sink";
           consumerDepth = createOp.size();
-          int shareDir = createOp.sharedMemValue(consumerIndex);
-          IntegerAttr intAttr = builder.getI32IntegerAttr(shareDir);
-          viaSharedMem = builder.getArrayAttr({intAttr});
-        } else {
-          llvm_unreachable("Neither via_DMA nor shared_mem set for fifo.");
-        }
+        } 
 
         auto consumerObjFifoSize =
             builder.getIntegerAttr(builder.getI32Type(), consumerDepth);
@@ -1346,13 +1376,14 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
         if (createOp.getVia_DMA()) {
           consumerFifo = createObjectFifo(
               builder, datatype, consumerFifoName, consumerTile, consumerTile,
-              consumerObjFifoSize, emptyDims, fromStreamDims, viaSharedMem);
+              consumerObjFifoSize, emptyDims, fromStreamDims);
         }
         else {
           consumerFifo = createObjectFifo(
               builder, datatype, consumerFifoName, producerTile, consumerTile,
-              consumerObjFifoSize, emptyDims, fromStreamDims, viaSharedMem);
+              consumerObjFifoSize, emptyDims, fromStreamDims, true);
         }
+
         if (createOp.getDisableSynchronization())
           consumerFifo.setDisableSynchronization(true);
         replaceSplitFifo(createOp, consumerFifo, consumerTileOp);
@@ -1377,15 +1408,10 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
       }
       
       if (!splitConsumerFifos.empty()) {
-        if (createOp.getViaSharedMem().has_value()) {
+        if (!createOp.getVia_DMA()) {
           splitNbrFifos.emplace_back(createOp, splitConsumerFifos);
           // update original fifo to be only mem-on-src consumers
           createOp.getConsumerTilesMutable().assign(memOnSrcConsumers);
-          if (createOp.numSharedMemConsumers(-1) != (int)createOp.getConsumerTiles().size())
-            createOp.emitOpError("No. of mem-on-src consumers ") 
-                                 << createOp.numSharedMemConsumers(-1)
-                                 << " should match no. of consumers "
-                                 << createOp.getConsumerTiles().size();
         } 
         else
           splitDmaFifos.emplace_back(createOp, splitConsumerFifos);
@@ -1450,13 +1476,8 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
       // if using 1-to-1 shared_memory, PnR decides if buffer will be on producer or
       // consumer side. Shared memory FIFOs with multiple consumers have to be
       // mem-on-src consumers, therefore direction = -1
-      if (createOp.getViaSharedMem().has_value()) {
-        if (createOp.numSharedMemConsumers(-1) > 1) {
+      if (!createOp.getVia_DMA()) {
           createObjectFifoElements(builder, lockAnalysis, createOp, -1);
-        }
-        else
-          createObjectFifoElements(builder, lockAnalysis, createOp,
-                                   createOp.sharedMemValue(0));
       }
       else {
         // check if split fifo is the copy or original; 
@@ -1555,15 +1576,14 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
     //===------------------------------------------------------------------===//
     // Create neighbour path ops TODO: see if we should keep this
     //===------------------------------------------------------------------===//
-    for (auto createOp : device.getOps<ObjectFifoCreateOp>()) {
-      if (createOp.getViaSharedMem().has_value()) {
-        builder.setInsertionPointAfter(createOp);
-        builder.create<NeighbourPathOp>(builder.getUnknownLoc(), 
-                                        createOp.getProducerTile(),
-                                        createOp.getConsumerTiles(),
-                                        createOp.getViaSharedMem().value());
-      }
-    }
+    // for (auto createOp : device.getOps<ObjectFifoCreateOp>()) {
+    //   if (createOp.getViaSharedMem().has_value()) {
+    //     builder.setInsertionPointAfter(createOp);
+    //     builder.create<NeighbourPathOp>(builder.getUnknownLoc(), 
+    //                                     createOp.getProducerTile(),
+    //                                     createOp.getConsumerTiles());
+    //   }
+    // }
     //===------------------------------------------------------------------===//
     // Statically unroll for loops 
     //===------------------------------------------------------------------===//
@@ -1802,7 +1822,7 @@ struct AIEObjectFifoToPathPass : public AIEObjectFifoToPathBase<AIEObjectFifoToP
     device.walk([&](Operation *op) {
       if (isa<ObjectFifoCreateOp, ObjectFifoLinkOp,
               ObjectFifoRegisterExternalBuffersOp, ObjectFifoAcquireOp,
-              ObjectFifoSubviewAccessOp, ObjectFifoReleaseOp>(op))
+              ObjectFifoSubviewAccessOp, ObjectFifoReleaseOp, ObjectFifoAllocateOp>(op))
         opsToErase.insert(op);
     });
     SmallVector<Operation *> sorted{opsToErase.begin(), opsToErase.end()};

--- a/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
@@ -56,6 +56,7 @@ struct AIEPlaceTilesPass : public AIEPlaceTilesBase<AIEPlaceTilesPass> {
 
     for (size_t i = 0; i < fifoOps.size(); i++) {
       auto fifoOp = fifoOps[i];
+      auto tileOps = llvm::to_vector(device.getOps<TileOp>());
       if (!input["nets"][i].contains("routing_info")) {
         fifoOp.emitError("No routing_info key found in JSON for net " + 
             std::to_string(input["nets"][i]["id"].get<int>()));
@@ -85,21 +86,39 @@ struct AIEPlaceTilesPass : public AIEPlaceTilesBase<AIEPlaceTilesPass> {
         fifoOp.setVia_DMAAttr(builder.getBoolAttr(true));
       }
       else if (route_info["connection_type"] == "neighbor_sharing") {
-        SmallVector<Attribute> shareDirectionAttrs;
-        for (const auto &dir : route_info["share_directions"]) {
-          int shareDirection = dir.get<int>();
-          shareDirectionAttrs.push_back(builder.getIntegerAttr(
-              builder.getI32Type(), shareDirection));
+        SmallVector<Value> delegateTileVals;
+        for (const auto &allocTile : route_info["allocation_tiles"]) {
+          int col = allocTile["col_x"];
+          int row = allocTile["row_y"];
+          bool found = false;
+
+          for (auto tile : tileOps) {
+            if (tile.getCol() == col && tile.getRow() == row) {
+              delegateTileVals.push_back(tile.getResult());
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            OpBuilder::InsertionGuard g(builder);
+            builder.setInsertionPointAfter(tileOps.back()); // insert after last existing TileOp
+            auto newTile =
+                builder.create<TileOp>(builder.getUnknownLoc(), col, row);
+            delegateTileVals.push_back(newTile.getResult());
+          }
         }
-        fifoOp.setViaSharedMemAttr(ArrayAttr::get(fifoOp.getContext(), 
-            shareDirectionAttrs));
+        OpBuilder::InsertionGuard g(builder);
+        builder.setInsertionPointAfter(fifoOp);
+        auto symRef = FlatSymbolRefAttr::get(builder.getContext(), fifoOp.getSymName());
+        builder.create<ObjectFifoAllocateOp>(builder.getUnknownLoc(), symRef, delegateTileVals);
       }
       else if (route_info["connection_type"] == "intra_tile") {
-        SmallVector<Attribute> shareDirectionAttrs;
-        shareDirectionAttrs.push_back(builder.getIntegerAttr(
-            builder.getI32Type(), -1));
-        fifoOp.setViaSharedMemAttr(ArrayAttr::get(fifoOp.getContext(), 
-            shareDirectionAttrs));
+        // SmallVector<Attribute> shareDirectionAttrs;
+        // shareDirectionAttrs.push_back(builder.getIntegerAttr(
+        //     builder.getI32Type(), -1));
+        // fifoOp.setViaSharedMemAttr(ArrayAttr::get(fifoOp.getContext(), 
+        //     shareDirectionAttrs));
+        continue;
       }
       else {
         fifoOp.emitError("Unsupported connection type in JSON");

--- a/lib/Dialect/AIE/Transforms/AIEReconstructRouting.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEReconstructRouting.cpp
@@ -280,8 +280,7 @@ struct AIEReconstructRoutingPass :
       }
     }
 
-    //std::set<Connection, ConnectionComparator> sharedMemConnect;
-    std::map<std::pair<TileOp, TileOp>, int> sharedMemConnect;
+    std::map<std::pair<TileOp, TileOp>, TileOp> sharedMemConnect;
     for (auto coreOp : device.getOps<CoreOp>()) {
       auto coreTileOp = coreOp.getTileOp();
       
@@ -294,22 +293,21 @@ struct AIEReconstructRoutingPass :
           // Determine connection direction depending on if it's producer lock
           std::pair<TileOp, TileOp> edge = isProd ? std::make_pair(lockTileOp, coreTileOp)
                                                   : std::make_pair(coreTileOp, lockTileOp);
-          int shareDir = isProd ? -1 : 1;
 
           // Check if overwriting existing entry
           if (sharedMemConnect.count(edge) == 0) {
-            sharedMemConnect[edge] = shareDir;
+            sharedMemConnect[edge] = lockTileOp;
           }
         }
       });
     }
 
-    for (auto &[tiles, shareDir] : sharedMemConnect) {
+    for (auto &[tiles, allocTile] : sharedMemConnect) {
       auto [srcTile, dstTile] = tiles;
       json connJson = {
         {"src", {{"col_x", srcTile.getCol()}, {"row_y", srcTile.getRow()}}},
         {"dst", {{"col_x", dstTile.getCol()}, {"row_y", dstTile.getRow()}}},
-        {"share_direction", shareDir}
+        {"allocation_tiles", {{"col_x", allocTile.getCol()}, {"row_y", allocTile.getRow()}}}
       };
       output["nbr_routes"].push_back(connJson);
     }

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -418,7 +418,7 @@ class object_fifo(ObjectFifoCreateOp):
         padDimensions=None,
         disable_synchronization=None,
         hop_tile_ids=None,
-        via_shared_mem=None,
+        allocation_tiles=None,
     ):
         self.datatype = try_convert_np_type_to_mlir_type(datatype)
         if not isinstance(consumerTiles, List):
@@ -436,11 +436,6 @@ class object_fifo(ObjectFifoCreateOp):
                     init_val = array("i", e)
                 values.append(DenseElementsAttr.get(init_val, type=self.datatype))
             initValues = _arrayAttr(values, None)
-        if via_shared_mem is not None:
-            values = []
-            for e in via_shared_mem:
-                values.append(IntegerAttr.get(T.i32(), e))
-            via_shared_mem = _arrayAttr(values, None)
         if hop_tile_ids is not None:
             outer_values = []
             for hop_path in hop_tile_ids:  # list[list[list[int]]]
@@ -466,8 +461,10 @@ class object_fifo(ObjectFifoCreateOp):
             disable_synchronization=disable_synchronization,
             initValues=initValues,
             hop_tile_ids=hop_tile_ids,
-            via_shared_mem=via_shared_mem,
         )
+        if allocation_tiles is not None:
+            tile_ops = [tile.op for tile in allocation_tiles]
+            self.allocate(tile_ops)
 
     def acquire(self, port, num_elem):
         subview_t = ObjectFifoSubviewType.get(self.datatype)
@@ -487,14 +484,8 @@ class object_fifo(ObjectFifoCreateOp):
     def release(self, port, num_elem):
         return objectfifo_release(port, self.sym_name.value, num_elem)
 
-    def set_via_shared_mem(self, port):
-        num = 0
-        if port == ObjectFifoPort.Produce:
-            num = 0
-        elif port == ObjectFifoPort.Consume:
-            num = 1
-        int_num = IntegerAttr.get(T.i32(), num)
-        self.attributes["via_shared_mem"] = int_num
+    def allocate(self, tiles):
+        return objectfifo_allocate(self.sym_name.value, tiles)
 
     def set_repeat_count(self, num):
         int_num = IntegerAttr.get(T.i32(), num)

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -78,7 +78,7 @@ class ObjectFifo(Resolvable):
         self._resolving = False
         self._via_dma: bool = False
         self._hop_tile_ids: list[list[list[int]]] | None = None
-        self._via_shared_mem: list[int] | None = None
+        self._allocation_tiles: list[Tile] | None = None
 
     @classmethod
     def __get_index(cls) -> int:
@@ -271,8 +271,8 @@ class ObjectFifo(Resolvable):
                 dimensionsFromStreamPerConsumer=dims_from_stream_per_cons,
                 plio=self._plio,
                 via_DMA=self._via_dma,
-                via_shared_mem=self._via_shared_mem,
                 hop_tile_ids=self._hop_tile_ids,
+                allocation_tiles=self._allocation_tiles,
             )
 
             if isinstance(self._prod.endpoint, ObjectFifoLink):
@@ -299,6 +299,13 @@ class ObjectFifo(Resolvable):
             raise ValueError("Must produce at least one element")
         self.op.release(port, num_elem)
 
+    def _allocate(
+        self,
+        tiles: list[Tile],
+    ):  
+        if not isinstance(tiles, list):
+            tiles = [tiles]
+        self._allocation_tiles = tiles
 
 class ObjectFifoHandle(Resolvable):
     """This class represents a handle to an ObjectFifo. A handle may be of type Producer or type Consumer."""

--- a/python/iron/placers.py
+++ b/python/iron/placers.py
@@ -226,9 +226,18 @@ class SAPlacer(Placer):
                 of._via_dma = True
                 of._hop_tile_ids = routing["intermediates"]
             elif routing["connection_type"] == "neighbor_sharing":
-                of._via_shared_mem = routing["share_directions"]
+                alloc_tiles = []
+                for tile_loc in routing["allocation_tiles"]:
+                    coord = (tile_loc["col_x"], tile_loc["row_y"])
+                    if coord not in coord_to_tile:
+                        t = Tile(*coord)
+                        coord_to_tile[coord] = t
+                        device.resolve_tile(t)
+                    alloc_tiles.append(coord_to_tile[coord])
+                of._allocate(alloc_tiles)
             elif routing["connection_type"] == "intra_tile":
-                of._via_shared_mem = [-1]
+                # TODO: apply allocate to other connection types
+                continue
             else:
                 raise ValueError(f"Unknown connection type {routing['connection_type']}")
         # Place buffers for workers


### PR DESCRIPTION
### Summary
This PR introduces the new `aie.objectfifo.allocate` operation from main MLIR-AIE repo to generalize buffer placement for ObjectFifos.
Instead of relying on the  `via_shared_mem` attribute, buffer placement is now explicitly declared by specifying the tile(s) it's placed on.

### Changes
- Extended the `allocate` op definition to have multiple delegate tiles since we can do _neighbor multicast_.
- Added Python bindings to generate `allocate`op during the PnR stage of **SAPlacer**, when a neighbor connection is selected.
- **Only applied** to neighbor connections, where each delegate tile must be either the producer or its corresponding consumer. _(No tile exists that is a neighbor of two other neighboring tiles.)_
- Updated **route reconstruction pass** to print allocation tile instead of shared direction.
- Shouldn't affect any existing test cases.

### TODO
- Consider further generalizing `allocate` to support any connection type.